### PR TITLE
Introduce logger script to disable console logs

### DIFF
--- a/OpprettTurnering.html
+++ b/OpprettTurnering.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">    
     <link rel="stylesheet" type="text/css" href="./admin.css">

--- a/basicscore.html
+++ b/basicscore.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Basic Scoreboard</title>

--- a/dommerdetaljer.html
+++ b/dommerdetaljer.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dommerdetaljer - Turnering</title>

--- a/dommere.html
+++ b/dommere.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dommere - Turnering</title>

--- a/faq.html
+++ b/faq.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script src="logger.js"></script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>FAQ – Frequently Asked Questions about Result Service</title>

--- a/format.html
+++ b/format.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
     <title>Velg format</title>
     <meta charset="utf-8">
     <link rel="stylesheet" type="text/css" href="./admin.css">

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
   <meta charset="UTF-8">
   <title>Simple Scores – Score Service</title>
   <meta name="description" content="Oppdag Simple Scores, din tjeneste for live resultater og oppdateringer.">

--- a/instillinger.html
+++ b/instillinger.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- Bruk den generelle CSS-filen -->

--- a/kampdetaljer.html
+++ b/kampdetaljer.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
     <meta charset="UTF-8">
     <title>Kampdetaljer - Turnering</title>
     <!-- Google Fonts -->

--- a/kamper.html
+++ b/kamper.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Kampoversikt Resultatservice</title>

--- a/kampliste.html
+++ b/kampliste.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Kamper - Turnering</title>

--- a/kampoppsett.html
+++ b/kampoppsett.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
     <head>
+    <script src="logger.js"></script>
         <title>Kampoppsett</title>
         <meta charset="utf-8">
         <link rel="stylesheet" type="text/css" href="./admin.css">

--- a/lagdetaljer.html
+++ b/lagdetaljer.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Lagdetaljer - Turnering</title>

--- a/lagoversikt.html
+++ b/lagoversikt.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Lagoversikt - Turnering</title>

--- a/leggtillag.html
+++ b/leggtillag.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <script src="logger.js"></script>
   <meta charset="utf8">
   <link rel="stylesheet" type="text/css" href="./admin.css">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">

--- a/logger.js
+++ b/logger.js
@@ -1,0 +1,11 @@
+(function() {
+  const ENABLE_LOGGING = false; // Set to true to enable console output
+  if (!ENABLE_LOGGING) {
+    const noop = function() {};
+    ['log', 'debug', 'info'].forEach(fn => {
+      if (console[fn]) {
+        console[fn] = noop;
+      }
+    });
+  }
+})();

--- a/login.html
+++ b/login.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
     <meta charset="utf-8">
     <title>Login</title>
     <link rel="stylesheet" type="text/css" href="./admin.css">

--- a/nyTurnering.html
+++ b/nyTurnering.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="./admin.css">

--- a/publikum.html
+++ b/publikum.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Turneringsoversikt</title>

--- a/registrer.html
+++ b/registrer.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
     <meta charset="UTF-8">
     <title>Register</title>
     <link rel="stylesheet" type="text/css" href="./admin.css">

--- a/scoreboard.html
+++ b/scoreboard.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Scoreboard</title>

--- a/settings.html
+++ b/settings.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Innstillinger for Scoreboard</title>

--- a/slideshow.html
+++ b/slideshow.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Turneringspresentasjon</title>

--- a/tabell.html
+++ b/tabell.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
   <meta charset="UTF-8" />
   <title>Alle divisjons- og fase-tabeller</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/turnering.html
+++ b/turnering.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
 <head>
+    <script src="logger.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Turneringsdetaljer - Turnering</title>


### PR DESCRIPTION
## Summary
- add `logger.js` to disable console logging in production
- include the script in all HTML files for easy log suppression

## Testing
- `npm run test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842dc4f95b4832dbbf413692282f55d