### PR TITLE
Implement Firebase role-based access

### DIFF
--- a/OpprettTurnering.html
+++ b/OpprettTurnering.html
@@ -222,13 +222,21 @@ const firebaseConfig = {
 
             
 auth.onAuthStateChanged((user) => {
-if (user) {
-const email = user.email;
-document.getElementById('mail').innerHTML = email;
-} else {
-// Ingen bruker er logget inn, redirect til innloggingssiden
-window.location.href = 'login.html';
-}
+  if (user) {
+    db.collection('users').doc(user.uid).get().then(doc => {
+      const role = doc.exists ? doc.data().role : 'publikum';
+      if (role !== 'arrangor') {
+        alert('Du har ikke tilgang til denne siden');
+        window.location.href = 'index.html';
+      } else {
+        const email = user.email;
+        document.getElementById('mail').innerHTML = email;
+      }
+    });
+  } else {
+    // Ingen bruker er logget inn, redirect til innloggingssiden
+    window.location.href = 'login.html';
+  }
 });
 
             document.addEventListener('DOMContentLoaded', () => {

--- a/instillinger.html
+++ b/instillinger.html
@@ -205,7 +205,15 @@
     
     auth.onAuthStateChanged((user) => {
       if (user) {
-        document.getElementById('mail').textContent = user.email;
+        db.collection('users').doc(user.uid).get().then(doc => {
+          const role = doc.exists ? doc.data().role : 'publikum';
+          if (role !== 'arrangor') {
+            alert('Du har ikke tilgang til denne siden');
+            window.location.href = 'index.html';
+          } else {
+            document.getElementById('mail').textContent = user.email;
+          }
+        });
       } else {
         window.location.href = 'login.html';
       }

--- a/kampoppsett.html
+++ b/kampoppsett.html
@@ -413,8 +413,16 @@ const firebaseConfig = {
 
             auth.onAuthStateChanged((user) => {
         if (user) {
-        const email = user.email;
-        document.getElementById('mail').innerHTML = email;
+        db.collection('users').doc(user.uid).get().then(doc => {
+            const role = doc.exists ? doc.data().role : 'publikum';
+            if (role !== 'arrangor') {
+                alert('Du har ikke tilgang til denne siden');
+                window.location.href = 'index.html';
+            } else {
+                const email = user.email;
+                document.getElementById('mail').innerHTML = email;
+            }
+        });
         } else {
         // Ingen bruker er logget inn, redirect til innloggingssiden
         window.location.href = 'login.html';

--- a/login.html
+++ b/login.html
@@ -212,8 +212,11 @@
             try {
                 const userCredential = await auth.signInWithEmailAndPassword(email, password);
                 const user = userCredential.user;
-                console.log("Bruker logget inn:", user.email);
-                
+                const userDoc = await db.collection('users').doc(user.uid).get();
+                const role = userDoc.exists ? userDoc.data().role : 'publikum';
+                localStorage.setItem('userRole', role);
+                console.log("Bruker logget inn:", user.email, role);
+
                 // Redirect til admin-siden etter innlogging
                 window.location.href = 'nyTurnering.html';
             } catch (error) {

--- a/nyTurnering.html
+++ b/nyTurnering.html
@@ -98,10 +98,18 @@
 
     auth.onAuthStateChanged((user) => {
       if (user) {
-        const email = user.email;
-        document.getElementById('mail').innerHTML = email;
-        loadTurnering(email);
-        loadCoArrangorTurneringer(email);
+        db.collection('users').doc(user.uid).get().then(doc => {
+          const role = doc.exists ? doc.data().role : 'publikum';
+          if (role !== 'arrangor') {
+            alert('Du har ikke tilgang til denne siden');
+            window.location.href = 'index.html';
+          } else {
+            const email = user.email;
+            document.getElementById('mail').innerHTML = email;
+            loadTurnering(email);
+            loadCoArrangorTurneringer(email);
+          }
+        });
       } else {
         window.location.href = 'login.html';
       }

--- a/registrer.html
+++ b/registrer.html
@@ -180,6 +180,8 @@
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
     <!-- Firebase Realtime Database -->
     <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-database.js"></script>
+    <!-- Firebase Firestore -->
+    <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-firestore.js"></script>
 </head>
 <body>
     <div class="container">
@@ -193,6 +195,10 @@
             <h2>Register</h2>
             <input type="email" id="email" placeholder="Email">
             <input type="password" id="password" placeholder="Password">
+            <select id="role">
+                <option value="arrangor">Arrangør (admin)</option>
+                <option value="publikum">Publikum</option>
+            </select>
             <button id="register">Register</button>
             <button onclick="LoggInn()">Already an account? Sign in</button>
             <p id="error-message"></p>
@@ -219,12 +225,18 @@
         document.getElementById('register').addEventListener('click', function() {
             var email = document.getElementById('email').value;
             var password = document.getElementById('password').value;
+            var role = document.getElementById('role').value;
             
             firebase.auth().createUserWithEmailAndPassword(email, password)
             .then((userCredential) => {
                 var user = userCredential.user;
-                document.getElementById('success-message').innerText = 'Bruker registrert!';
-                document.getElementById('error-message').innerText = '';
+                firebase.firestore().collection('users').doc(user.uid).set({
+                    email: email,
+                    role: role
+                }).then(() => {
+                    document.getElementById('success-message').innerText = 'Bruker registrert!';
+                    document.getElementById('error-message').innerText = '';
+                });
             })
             .catch((error) => {
                 var errorMessage = error.message;

--- a/scoreboard.html
+++ b/scoreboard.html
@@ -585,11 +585,19 @@ const rtdb = firebase.database();                                  // <-- Nytt
                           
         auth.onAuthStateChanged((user) => {
         if (user) {
-        const email = user.email;
-
+            db.collection('users').doc(user.uid).get().then(doc => {
+                const role = doc.exists ? doc.data().role : 'publikum';
+                if (role !== 'arrangor') {
+                    alert('Du har ikke tilgang til denne siden');
+                    window.location.href = 'index.html';
+                } else {
+                    const email = user.email;
+                    document.getElementById('mail') && (document.getElementById('mail').innerHTML = email);
+                }
+            });
         } else {
-        // Ingen bruker er logget inn, redirect til innloggingssiden
-        window.location.href = 'login.html';
+            // Ingen bruker er logget inn, redirect til innloggingssiden
+            window.location.href = 'login.html';
         }
         });
 


### PR DESCRIPTION
## Summary
- add role selector and Firestore role storing in `registrer.html`
- fetch and store user roles on login
- restrict admin pages to organiser or referee roles
- deny access on `scoreboard.html`, `OpprettTurnering.html`, `nyTurnering.html`, `kampoppsett.html`, and `instillinger.html` if role is not allowed
- remove referee role from registration and access checks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842dc73c870832dbe98b791b6cf90c6