### PR TITLE
Remove Firestore users collection references

### DIFF
--- a/OpprettTurnering.html
+++ b/OpprettTurnering.html
@@ -216,16 +216,8 @@
             
 auth.onAuthStateChanged((user) => {
   if (user) {
-    db.collection('users').doc(user.uid).get().then(doc => {
-      const role = doc.exists ? doc.data().role : 'publikum';
-      if (role !== 'arrangor') {
-        alert('Du har ikke tilgang til denne siden');
-        window.location.href = 'index.html';
-      } else {
-        const email = user.email;
-        document.getElementById('mail').innerHTML = email;
-      }
-    });
+    const email = user.email;
+    document.getElementById('mail').innerHTML = email;
   } else {
     // Ingen bruker er logget inn, redirect til innloggingssiden
     window.location.href = 'login.html';

--- a/instillinger.html
+++ b/instillinger.html
@@ -197,15 +197,7 @@
     
     auth.onAuthStateChanged((user) => {
       if (user) {
-        db.collection('users').doc(user.uid).get().then(doc => {
-          const role = doc.exists ? doc.data().role : 'publikum';
-          if (role !== 'arrangor') {
-            alert('Du har ikke tilgang til denne siden');
-            window.location.href = 'index.html';
-          } else {
-            document.getElementById('mail').textContent = user.email;
-          }
-        });
+        document.getElementById('mail').textContent = user.email;
       } else {
         window.location.href = 'login.html';
       }

--- a/kampoppsett.html
+++ b/kampoppsett.html
@@ -406,21 +406,13 @@
 
             auth.onAuthStateChanged((user) => {
         if (user) {
-        db.collection('users').doc(user.uid).get().then(doc => {
-            const role = doc.exists ? doc.data().role : 'publikum';
-            if (role !== 'arrangor') {
-                alert('Du har ikke tilgang til denne siden');
-                window.location.href = 'index.html';
-            } else {
                 const email = user.email;
                 document.getElementById('mail').innerHTML = email;
-            }
-        });
         } else {
         // Ingen bruker er logget inn, redirect til innloggingssiden
         window.location.href = 'login.html';
         }
-        });
+            });
         function loggut() {
     auth.signOut().then(() => {
         window.location.href = 'login.html';

--- a/login.html
+++ b/login.html
@@ -189,14 +189,13 @@
     <script src="https://www.gstatic.com/firebasejs/8.2.0/firebase-app.js"></script>
     <script src="firebaseConfig.js"></script>
     <script src="https://www.gstatic.com/firebasejs/8.2.0/firebase-auth.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/8.2.0/firebase-firestore.js"></script>
+
     
     <script>
 
         // Initialize Firebase
         firebase.initializeApp(firebaseConfig);
         const auth = firebase.auth();
-        const db = firebase.firestore();
 
         async function login() {
             const email = document.getElementById('email').value;
@@ -204,10 +203,7 @@
             try {
                 const userCredential = await auth.signInWithEmailAndPassword(email, password);
                 const user = userCredential.user;
-                const userDoc = await db.collection('users').doc(user.uid).get();
-                const role = userDoc.exists ? userDoc.data().role : 'publikum';
-                localStorage.setItem('userRole', role);
-                console.log("Bruker logget inn:", user.email, role);
+                console.log("Bruker logget inn:", user.email);
 
                 // Redirect til admin-siden etter innlogging
                 window.location.href = 'nyTurnering.html';

--- a/nyTurnering.html
+++ b/nyTurnering.html
@@ -91,18 +91,10 @@
 
     auth.onAuthStateChanged((user) => {
       if (user) {
-        db.collection('users').doc(user.uid).get().then(doc => {
-          const role = doc.exists ? doc.data().role : 'publikum';
-          if (role !== 'arrangor') {
-            alert('Du har ikke tilgang til denne siden');
-            window.location.href = 'index.html';
-          } else {
-            const email = user.email;
-            document.getElementById('mail').innerHTML = email;
-            loadTurnering(email);
-            loadCoArrangorTurneringer(email);
-          }
-        });
+        const email = user.email;
+        document.getElementById('mail').innerHTML = email;
+        loadTurnering(email);
+        loadCoArrangorTurneringer(email);
       } else {
         window.location.href = 'login.html';
       }

--- a/scoreboard.html
+++ b/scoreboard.html
@@ -155,16 +155,8 @@ const rtdb = firebase.database();                                  // <-- Nytt
                           
         auth.onAuthStateChanged((user) => {
         if (user) {
-            db.collection('users').doc(user.uid).get().then(doc => {
-                const role = doc.exists ? doc.data().role : 'publikum';
-                if (role !== 'arrangor') {
-                    alert('Du har ikke tilgang til denne siden');
-                    window.location.href = 'index.html';
-                } else {
-                    const email = user.email;
-                    document.getElementById('mail') && (document.getElementById('mail').innerHTML = email);
-                }
-            });
+            const email = user.email;
+            document.getElementById('mail') && (document.getElementById('mail').innerHTML = email);
         } else {
             // Ingen bruker er logget inn, redirect til innloggingssiden
             window.location.href = 'login.html';


### PR DESCRIPTION
## Summary
- simplify login logic and drop Firestore `users` collection lookup
- allow any authenticated user to access pages that previously checked user roles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842e5283db0832db656735361d0e781