### PR TITLE
Fix admin button styles with Tailwind

### DIFF
--- a/admin.css
+++ b/admin.css
@@ -214,7 +214,7 @@ main {
 }
 
 /* Button Styling */
-button {
+button:not([class]) {
     background-color: #4f46e5; /* indigo-600 */
     color: white;
     padding: 0.5rem 1rem;
@@ -227,13 +227,13 @@ button {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
-button:hover {
+button:not([class]):hover {
     background-color: #4338ca; /* indigo-700 */
     transform: scale(1.05);
 }
 
 /* Disabled Button */
-button[disabled] {
+button:not([class])[disabled] {
     background-color: #cccccc;
     cursor: not-allowed;
     box-shadow: none;

--- a/style.css
+++ b/style.css
@@ -395,7 +395,7 @@ main {
 }
 
 /* Button Styling */
-button {
+button:not([class]) {
     background-color: #4c51bf;
     color: white;
     padding: 12px 24px;
@@ -407,13 +407,13 @@ button {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
-button:hover {
+button:not([class]):hover {
     background-color: #434190;
     transform: scale(1.05);
 }
 
 /* Disabled Button */
-button[disabled] {
+button:not([class])[disabled] {
     background-color: #cccccc;
     cursor: not-allowed;
     box-shadow: none;


### PR DESCRIPTION
## Summary
- prevent admin.css and style.css from overriding Tailwind button styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844111d1b8c832db4cb3410a2b097aa