### PR TITLE
Fix admin button styles with Tailwind

### DIFF
--- a/admin.css
+++ b/admin.css
@@ -214,7 +214,7 @@ main {
 }
 
 /* Button Styling */
-button {
+button:not([class]) {
     background-color: #4f46e5; /* indigo-600 */
     color: white;
     padding: 0.5rem 1rem;
@@ -227,13 +227,47 @@ button {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
-button:hover {
+button:not([class]):hover {
     background-color: #4338ca; /* indigo-700 */
     transform: scale(1.05);
 }
 
 /* Disabled Button */
-button[disabled] {
+button:not([class])[disabled] {
+    background-color: #cccccc;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+/* Legacy Bootstrap-style buttons */
+.btn,
+.btn-primary,
+.btn-secondary,
+.btn-danger {
+    background-color: #4f46e5;
+    color: white;
+    padding: 0.5rem 1rem;
+    border: none;
+    border-radius: 0.375rem;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s ease, transform 0.2s;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.btn:hover,
+.btn-primary:hover,
+.btn-secondary:hover,
+.btn-danger:hover {
+    background-color: #4338ca;
+    transform: scale(1.05);
+}
+
+.btn[disabled],
+.btn-primary[disabled],
+.btn-secondary[disabled],
+.btn-danger[disabled] {
     background-color: #cccccc;
     cursor: not-allowed;
     box-shadow: none;

--- a/style.css
+++ b/style.css
@@ -395,7 +395,7 @@ main {
 }
 
 /* Button Styling */
-button {
+button:not([class]) {
     background-color: #4c51bf;
     color: white;
     padding: 12px 24px;
@@ -407,13 +407,46 @@ button {
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
-button:hover {
+button:not([class]):hover {
     background-color: #434190;
     transform: scale(1.05);
 }
 
 /* Disabled Button */
-button[disabled] {
+button:not([class])[disabled] {
+    background-color: #cccccc;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+/* Legacy Bootstrap-style buttons */
+.btn,
+.btn-primary,
+.btn-secondary,
+.btn-danger {
+    background-color: #4c51bf;
+    color: white;
+    padding: 12px 24px;
+    border: none;
+    border-radius: 8px;
+    font-size: 16px;
+    cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.2s;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.btn:hover,
+.btn-primary:hover,
+.btn-secondary:hover,
+.btn-danger:hover {
+    background-color: #434190;
+    transform: scale(1.05);
+}
+
+.btn[disabled],
+.btn-primary[disabled],
+.btn-secondary[disabled],
+.btn-danger[disabled] {
     background-color: #cccccc;
     cursor: not-allowed;
     box-shadow: none;


### PR DESCRIPTION
## Summary
- prevent admin.css and style.css from overriding Tailwind button styles
- add fallback styles for legacy `.btn` button classes so they are not transparent

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6844111d1b8c832db4cb3410a2b097aa