### PR TITLE
Fix division dropdown text color

### DIFF
--- a/admin.css
+++ b/admin.css
@@ -291,6 +291,13 @@ select {
     cursor: pointer;
 }
 
+/* Ensure readable text in the division dropdown */
+#divisionDropdown,
+#divisionDropdown option {
+    color: #2d3e50;
+    background-color: #ffffff;
+}
+
 select:focus {
     outline: none;
     border-color: #4c51bf;


### PR DESCRIPTION
## Summary
- ensure readable text in division dropdown by explicitly setting color and background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684414a1d588832d8319240be30b849a