### PR TITLE
Implement tabbed edit view for teams and referees

### DIFF
--- a/leggtillag.html
+++ b/leggtillag.html
@@ -167,6 +167,68 @@
     .modal-content .add-player-container button:hover {
       background-color: #4a5ddd;
     }
+
+    /* Tabs and cards */
+    .tabs {
+      display: flex;
+      gap: 10px;
+      margin-bottom: 20px;
+    }
+    .tab-btn {
+      padding: 8px 16px;
+      background-color: #eee;
+      border: none;
+      cursor: pointer;
+      border-radius: 4px;
+    }
+    .tab-btn.active {
+      background-color: #596bff;
+      color: #fff;
+    }
+    .tab-section { display: none; }
+    .tab-section.active { display: block; }
+    .actions { margin-bottom: 10px; display: flex; gap: 10px; align-items: center; }
+
+    .card-list {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 1rem;
+    }
+    .team-card, .ref-card {
+      background: #fff;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 1rem;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+      cursor: pointer;
+      position: relative;
+    }
+    .team-card .actions, .ref-card .actions {
+      margin-top: 0.5rem;
+      display: flex;
+      gap: 5px;
+    }
+    .team-card button, .ref-card button {
+      background-color: #596bff;
+      color: #fff;
+      border: none;
+      padding: 4px 8px;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 0.8rem;
+    }
+    .team-card button:hover, .ref-card button:hover { background-color: #4a5ddd; }
+
+    @media (min-width: 768px) {
+      .modal.desktop .modal-content {
+        right: 0;
+        left: auto;
+        top: 0;
+        transform: none;
+        height: 100%;
+        border-radius: 0;
+      }
+    }
   </style>
 </head>
 <body>
@@ -217,12 +279,12 @@
       <input type="text" id="teamName" name="teamName" placeholder="Skriv lagnavn"><br>
       <label for="spillerliste">Playerlist:</label>
       <textarea id="spillerliste" rows="5" placeholder="Type in playernames, one per line" name="spillerliste"></textarea>
-      <button onclick="addTeam()" type="button">Add team</button>
+      <button id="saveTeamBtn" onclick="saveTeam()" type="button">Add team</button>
     </form>
   </div>
 </div>
 
-    
+
     <!-- The Modal for spillere -->
     <div id="myModal" class="modal" style="display: none;">
       <div class="modal-content">
@@ -233,7 +295,7 @@
         <button onclick="leggTilSpiller()" id="addplayer" type="button">Add player</button>
       </div>
     </div>
-    
+
 <!-- Referee Form Popup -->
 <div id="refereeForm" class="modal">
   <div class="modal-content">
@@ -253,65 +315,35 @@
         <!-- JS fyller ut én checkbox per divisjon -->
       </div>
 
-      <button type="button" onclick="addReferee()">Add Referee</button>
+      <button id="saveRefBtn" type="button" onclick="saveReferee()">Add Referee</button>
     </form>
   </div>
 </div>
 
 
-    
+
     <!-- Innhold for lag og dommere -->
-    <div class="legg-til-lag-container">
-      <div class="tabell">
-        <table id="lagTabell">
-          <thead>
-            <!-- Rad for divisjonsvalg og Legg til Lag-knappen -->
-            <tr>
-              <th>
-                <select id="divisionDropdown" onchange="hentOgVisLag()">
-                  <!-- Divisjoner vil bli populert her av JavaScript -->
-                </select>
-              </th>
-              <th>
-                <button id="addTeamBtn" onclick="Endre()">Add team</button>
-              </th>
-            </tr>
-            <!-- Rad for overskriftene i tabellen -->
-            <tr>
-              <th>Teamname</th>
-              <th>Action</th>
-            </tr>
-          </thead>
-          <tbody>
-            <!-- Lagdata vil bli injisert her -->
-          </tbody>
-        </table>
+    <div class="tabs">
+      <button class="tab-btn active" onclick="showTab('teams', this)">Teams</button>
+      <button class="tab-btn" onclick="showTab('refs', this)">Referees</button>
+    </div>
+    <div id="teams" class="tab-section active">
+      <div class="actions">
+        <select id="divisionDropdown" onchange="hentOgVisLag()">
+          <!-- Divisjoner vil bli populert her av JavaScript -->
+        </select>
+        <button id="addTeamBtn" onclick="openTeamForm()">Add team</button>
       </div>
+      <div id="lagContainer" class="card-list"></div>
     </div>
-    
-    <div class="tabell">
-      <table id="dommeroversikt">
-        <thead>
-          <tr>
-            <th colspan="4">
-              <button id="addref" onclick="visform()">Add referee</button>
-            </th>
-          </tr>
-          <tr>
-            <th>Name</th>
-            <th>Team</th>
-            <th>Divisions</th>
-            <th>Delete</th>
-          </tr>
-        </thead>
-        <tbody>
-          <!-- ... -->
-        </tbody>
-      </table>
-      
-      
+
+    <div id="refs" class="tab-section">
+      <div class="actions">
+        <button id="addref" onclick="openRefereeForm()">Add referee</button>
+      </div>
+      <div id="dommerListe" class="card-list"></div>
     </div>
-    
+
   </main>
   <footer class="site-footer">
     <div class="footer-container">
@@ -336,6 +368,8 @@
     const app = firebase.initializeApp(firebaseConfig);
     const db = firebase.firestore();
     const auth = firebase.auth();
+    let editingTeamId = null;
+    let editingRefereeId = null;
     
     auth.onAuthStateChanged((user) => {
       if (user) {
@@ -371,8 +405,23 @@
 }
 
     // Funksjoner for lag og dommere
-    function Endre(){
-      document.getElementById("teamPopup").style.display = "block";
+    function openTeamForm(id){
+      editingTeamId = id || null;
+      document.getElementById('saveTeamBtn').textContent = editingTeamId ? 'Save team' : 'Add team';
+      document.getElementById('teamName').value = '';
+      document.getElementById('spillerliste').value = '';
+      if(id){
+        db.collection('turneringer').doc(turneringId).collection('lag').doc(id).get().then(doc => {
+          if(doc.exists){
+            const data = doc.data();
+            document.getElementById('teamName').value = data.lagNavn || '';
+            document.getElementById('spillerliste').value = (data.spillere || []).join('\n');
+          }
+        });
+      }
+      const modal = document.getElementById('teamPopup');
+      if(window.innerWidth >= 768){ modal.classList.add('desktop'); } else { modal.classList.remove('desktop'); }
+      modal.style.display = 'block';
     }
     
     async function populateDivisionDropdown() {
@@ -462,96 +511,87 @@ document.addEventListener('DOMContentLoaded', () => {
 }
 
 
-    function visform(){
-      document.getElementById("refereeForm").style.display= "block";
+    function openRefereeForm(id){
+      editingRefereeId = id || null;
+      document.getElementById('saveRefBtn').textContent = editingRefereeId ? 'Save' : 'Add Referee';
+      document.getElementById('refereeName').value = '';
+      document.getElementById('refereeTeam').value = '';
+      populateDivisionsCheckboxes().then(() => {
+        if(id){
+          db.collection('turneringer').doc(turneringId).collection('dommere').doc(id).get().then(doc => {
+            if(doc.exists){
+              const data = doc.data();
+              document.getElementById('refereeName').value = data.dommer || '';
+              document.getElementById('refereeTeam').value = data.teamId || '';
+              if(data.divisions){
+                const checkboxes = document.querySelectorAll('#refereeDivisionsContainer input[name="refereeDivisions"]');
+                checkboxes.forEach(cb => { cb.checked = data.divisions.includes(cb.value); });
+              }
+            }
+          });
+        }
+      });
+      const modal = document.getElementById('refereeForm');
+      if(window.innerWidth >= 768){ modal.classList.add('desktop'); } else { modal.classList.remove('desktop'); }
+      modal.style.display= "block";
     }
     
-    function addTeam() {
-  // Hent og nullstill skjema
-  const lagNavn = document.forms["addTeamForm"]["teamName"].value.trim();
-  document.forms["addTeamForm"]["teamName"].value = '';
+    function saveTeam() {
+      const lagNavn = document.getElementById('teamName').value.trim();
+      const spillerliste = document.getElementById('spillerliste')
+        .value
+        .split('\n')
+        .map(s => s.trim())
+        .filter(s => s);
+      const div = document.getElementById('divisionDropdown').value;
 
-  // Hent spillerliste fra textarea, én spiller per linje
-  const spillerliste = document.getElementById('spillerliste')
-    .value
-    .split('\n')
-    .map(spiller => spiller.trim())
-    .filter(spiller => spiller);
-  document.forms["addTeamForm"]["spillerliste"].value = '';
+      const lagData = { lagNavn: lagNavn, spillere: spillerliste, divisjon: div };
+      const teamsRef = db.collection('turneringer').doc(turneringId).collection('lag');
 
-  // Velg divisjon
-  const div = document.getElementById("divisionDropdown").value;
+      const p = editingTeamId
+        ? teamsRef.doc(editingTeamId).set(lagData)
+        : teamsRef.add(lagData);
 
-  // Bygg objektet som skal lagres
-  const lagData = {
-    lagNavn: lagNavn,
-    spillere: spillerliste,
-    divisjon: div,
-  };
-
-  // Referanse til samlingen
-  const teamsRef = db
-    .collection('turneringer')
-    .doc(turneringId)
-    .collection('lag');
-
-  // .add() gir deg en tilfeldig, godkjent ID — uavhengig av innholdet i lagNavn
-  teamsRef.add(lagData)
-    .then(docRef => {
-      console.log('Lag lagret med tilfeldig ID:', docRef.id);
-      // Sett dropdown tilbake til det valget brukeren hadde
-      document.getElementById('divisionDropdown').value = div;
-      hentOgVisLag();
-    })
-    .catch(error => {
-      console.error('Feil ved lagring av lag med add():', error);
-    });
-}
+      p.then(() => {
+          document.getElementById('teamPopup').style.display = 'none';
+          editingTeamId = null;
+          hentOgVisLag();
+        })
+        .catch(error => console.error('Feil ved lagring av lag:', error));
+    }
 
     function hentOgVisLag() {
-      if (!turneringId) {
-        console.error('No tournament ID provided');
-        return;
-      }
+      if (!turneringId) return;
       const selectedDivision = document.getElementById('divisionDropdown').value;
-      if (!selectedDivision) {
-        console.log('Ingen divisjon valgt');
-        return;
-      }
+      if (!selectedDivision) return;
+
       db.collection('turneringer').doc(turneringId).collection('lag')
         .where('divisjon', '==', selectedDivision)
         .get()
         .then(snapshot => {
-          const lagTabell = document.getElementById('lagTabell');
-          const tbody = lagTabell.querySelector('tbody');
-          tbody.innerHTML = '';
+          const container = document.getElementById('lagContainer');
+          container.innerHTML = '';
           snapshot.forEach(doc => {
             const lag = doc.data();
-            const row = tbody.insertRow();
-            const lagNavnCell = row.insertCell(0);
-            lagNavnCell.textContent = lag.lagNavn;
-            const lagId = doc.id;
-            const knappCell = row.insertCell(1);
-            knappCell.classList.add('knapper-cell');
-            const visSpillereKnapp = document.createElement('button');
-            visSpillereKnapp.textContent = 'Show players';
-            visSpillereKnapp.onclick = function() {
-              visSpillere(lagId);
-            };
-            visSpillereKnapp.classList.add('handlingsknapp');
-            knappCell.appendChild(visSpillereKnapp);
-            const slettKnapp = document.createElement('button');
-            slettKnapp.textContent = 'Delete';
-            slettKnapp.classList.add('handlingsknapp');
-            slettKnapp.onclick = function() {
-              slettLag(lagId);
-            };
-            knappCell.appendChild(slettKnapp);
+            const card = document.createElement('div');
+            card.className = 'team-card';
+            card.innerHTML = `<h3>${lag.lagNavn}</h3>`;
+            card.addEventListener('click', () => openTeamForm(doc.id));
+            const actions = document.createElement('div');
+            actions.className = 'actions';
+            const playersBtn = document.createElement('button');
+            playersBtn.textContent = 'Players';
+            playersBtn.onclick = (e) => { e.stopPropagation(); visSpillere(doc.id); };
+            const delBtn = document.createElement('button');
+            delBtn.textContent = 'Delete';
+            delBtn.onclick = (e) => { e.stopPropagation(); slettLag(doc.id); };
+            actions.appendChild(playersBtn);
+            actions.appendChild(delBtn);
+            card.appendChild(actions);
+            container.appendChild(card);
           });
         })
-        .catch(error => {
-          console.error("Error fetching teams: ", error);
-        });
+        .catch(error => console.error('Error fetching teams: ', error));
     }
     
     function visSpillere(lagId) {
@@ -618,6 +658,13 @@ document.addEventListener('DOMContentLoaded', () => {
       const sidebar = document.getElementById('sidebar');
       sidebar.classList.toggle('open');
     }
+
+    function showTab(id, btn){
+      document.querySelectorAll('.tab-section').forEach(s => s.classList.remove('active'));
+      document.getElementById(id).classList.add('active');
+      document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+      if(btn) btn.classList.add('active');
+    }
     
     function leggTilSpiller(spillerNavn, lagId) {
       const lagRef = db.collection('turneringer').doc(turneringId).collection('lag').doc(lagId);
@@ -651,7 +698,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     
   // 3) Les av valgte divisjoner i addReferee()
-function addReferee(){
+function saveReferee(){
   const name       = document.getElementById('refereeName').value;
   const teamEl     = document.getElementById('refereeTeam');
   const teamId     = teamEl.value;
@@ -676,12 +723,13 @@ function addReferee(){
   teamEl.value                             = '';
   checkedEls.forEach(cb => cb.checked       = false);
 
-  db.collection('turneringer')
-    .doc(turneringId)
-    .collection('dommere')
-    .doc()
-    .set(dommerdata)
-    .then(hentDommere)
+  const ref = db.collection('turneringer').doc(turneringId).collection('dommere');
+  const p = editingRefereeId ? ref.doc(editingRefereeId).set(dommerdata) : ref.doc().set(dommerdata);
+  p.then(() => {
+      document.getElementById('refereeForm').style.display = 'none';
+      editingRefereeId = null;
+      hentDommere();
+    })
     .catch(console.error);
 }
 
@@ -692,26 +740,22 @@ function hentDommere() {
     .collection('dommere')
     .get()
     .then(snapshot => {
-      const table = document.getElementById('dommeroversikt');
-      while (table.rows.length > 2) table.deleteRow(2);
-
+      const container = document.getElementById('dommerListe');
+      container.innerHTML = '';
       snapshot.forEach(doc => {
         const data = doc.data();
-        const row = table.insertRow();
-
-        row.insertCell(0).textContent = data.dommer;
-        row.insertCell(1).textContent = data.teamName || '—';
-
-        const divCell = row.insertCell(2);
-        divCell.textContent = (data.divisions && data.divisions.length)
-          ? data.divisions.join(', ')
-          : '—';
-
-        const delCell = row.insertCell(3);
-        const btn = document.createElement('button');
-        btn.textContent = 'Delete';
-        btn.onclick = () => deleteReferee(doc.id);
-        delCell.appendChild(btn);
+        const card = document.createElement('div');
+        card.className = 'ref-card';
+        card.innerHTML = `<h3>${data.dommer}</h3><p>${data.teamName || '—'}</p>`;
+        card.addEventListener('click', () => openRefereeForm(doc.id));
+        const actions = document.createElement('div');
+        actions.className = 'actions';
+        const delBtn = document.createElement('button');
+        delBtn.textContent = 'Delete';
+        delBtn.onclick = (e) => { e.stopPropagation(); deleteReferee(doc.id); };
+        actions.appendChild(delBtn);
+        card.appendChild(actions);
+        container.appendChild(card);
       });
     })
     .catch(console.error);


### PR DESCRIPTION
## Summary
- add tab layout with team and referee cards
- open team/referee in side panel or popup
- update scripts for editing teams and referees
- refactor list rendering to use cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684417fcf850832dbe0b301775a543f3