### PR TITLE
Add goal scorer logging toggle

### DIFF
--- a/scoreboard.html
+++ b/scoreboard.html
@@ -204,6 +204,7 @@ let pauseDuration;   // Pauselengde, satt fra innstillingene
         let timeBegin;
         let storedTimeLeft; // For å lagre tiden før timeout
         let originalTimeLeft; // For å lagre tiden før timeout start
+        let logGoalScorersEnabled = true; // Kan deaktiveres via innstillinger
         // Global variabel for kampens fase – "utslag" for utslagskamper
 let matchPhase;
 
@@ -279,6 +280,9 @@ async function hentInnstillinger(division) {
             timeBegin      = timeLeft;  // vi bruker samme verdi til restart
             timeoutDuration = parseInt(settings.timeoutDuration, 10) || 30;
             pauseDuration   = parseInt(settings.pauseDuration, 10)   || 60;
+            logGoalScorersEnabled =
+                settings.logGoalScorers === undefined ? true
+                                                     : Boolean(settings.logGoalScorers);
             console.log("pauseDuration satt til:", pauseDuration);
 
         } else {
@@ -1395,6 +1399,11 @@ async function updateTeamStatsAfterReset(hjemmelag, bortelag, hjemmeScore, borte
 
         // Funksjon for å åpne spiller-popup
         async function openPlayerModal(team) {
+            if (!logGoalScorersEnabled) {
+                await logGoalAndUpdateScore('ikke-definert', team);
+                return;
+            }
+
             const playerListElement = document.getElementById('playerList');
             playerListElement.innerHTML = ''; // Tøm listen først
 

--- a/settings.html
+++ b/settings.html
@@ -123,6 +123,11 @@
             <label for="pauseDuration">Pauselengde (sekunder)</label>
             <input type="number" id="pauseDuration" value="60">
         </div>
+
+        <div class="form-group">
+            <label for="logGoalScorers">Logg målscorere</label>
+            <input type="checkbox" id="logGoalScorers" checked>
+        </div>
         
 
         <button onclick="saveSettings()">Lagre innstillinger</button>
@@ -230,6 +235,7 @@
     const numPeriods = document.getElementById('numPeriods').value;
     const timeoutDuration = document.getElementById('timeoutDuration').value;
     const pauseDuration = document.getElementById('pauseDuration').value;  // Ny variabel
+    const logGoalScorers = document.getElementById('logGoalScorers').checked;
 
     // Lagre innstillingene i Firestore under turneringen
     db.collection('turneringer').doc(turneringId)
@@ -238,7 +244,8 @@
             halfDuration: parseInt(halfDuration),
             numPeriods: parseInt(numPeriods),
             timeoutDuration: parseInt(timeoutDuration),
-            pauseDuration: parseInt(pauseDuration)  // Lagre den nye innstillingen
+            pauseDuration: parseInt(pauseDuration),  // Lagre den nye innstillingen
+            logGoalScorers: logGoalScorers
       })
       .then(() => {
           document.getElementById('settingsSaved').style.display = 'block';


### PR DESCRIPTION
## Summary
- add checkbox in settings to enable or disable logging of goal scorers
- store the setting in Firestore via `saveSettings`
- fetch the setting in scoreboard and respect it
- bypass player selection when logging is disabled

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684418c445a4832dac8da31e0f480fce