### PR TITLE
Adjust scoreboard font sizes for laptops

### DIFF
--- a/basicscore.html
+++ b/basicscore.html
@@ -92,14 +92,14 @@
     }
 
     /* Timer og omgangen */
-    #timer { font-size: 6vw; margin-bottom: .5rem; letter-spacing: 4px; }
-    #period { font-size: 3vw; margin-bottom: 1rem; text-transform: uppercase; }
+    #timer { font-size: min(6vw, 10vh); margin-bottom: .5rem; letter-spacing: 4px; }
+    #period { font-size: min(3vw, 4vh); margin-bottom: 1rem; text-transform: uppercase; }
 
     /* Score-seksjon */
     .scores { display: flex; justify-content: space-between; width: 100%; }
     .score-section { flex: 1; display: flex; flex-direction: column; align-items: center; margin: 0 .5rem; }
-    .score { font-size: 9vw; color: #007bff; margin-bottom: .5rem; }
-    .team-name { font-size: 3vw; margin-bottom: 1rem; text-transform: uppercase; }
+    .score { font-size: min(9vw, 10vh); color: #007bff; margin-bottom: .5rem; }
+    .team-name { font-size: min(3vw, 4vh); margin-bottom: 1rem; text-transform: uppercase; }
 
     /* Knapp-styling */
     .score-button, .controls button { font-size: 1.25rem; padding: .75rem 1rem; border: none; border-radius: 10px; background: #007bff; color: #fff; cursor: pointer; transition: background .3s, transform .2s; }
@@ -112,8 +112,8 @@
     .modal-content { background: #fff; padding: 1.5rem; border-radius: 10px; text-align: center; }
 
     @media(max-width:768px) {
-        #timer, .score { font-size: 12vw; }
-        #period, .team-name { font-size: 5vw; }
+        #timer, .score { font-size: min(12vw, 15vh); }
+        #period, .team-name { font-size: min(5vw, 6vh); }
         .score-button, .controls button, .side-panel button { width: 120px; height: 50px; font-size: 1.5rem; padding: .5rem .75rem; }
         .scoreboard { max-width: 90%; }
     }

--- a/scoreboard.css
+++ b/scoreboard.css
@@ -187,7 +187,7 @@
     
       /* Øk font-størrelsen på tidtakeren */
       .timer {
-          font-size: 12vw;    /* var 6vw */
+          font-size: min(12vw, 10vh);    /* Begrens høyden for laptopskjermer */
           margin-bottom: 0.5rem;
           letter-spacing: 4px;
           color: #2d3e50;
@@ -196,14 +196,14 @@
     
       /* Øk font-størrelsen på poengsummen */
       .score {
-          font-size: 12vw;   /* var 9vw */
+          font-size: min(12vw, 10vh);   /* Tilpass for mindre skjermer */
           text-align: center;
           margin-bottom: 0.5rem;
           color: #007bff;
       }
     
       .timeout-timer {
-          font-size: 3vw;
+          font-size: min(3vw, 4vh);
           margin-bottom: 1rem;
           color: #ff5722;
           text-align: center;
@@ -212,7 +212,7 @@
     
       /* Period */
       .period {
-          font-size: 3vw;
+          font-size: min(3vw, 4vh);
           margin-bottom: 1rem;
           text-transform: uppercase;
           color: #2d3e50;
@@ -237,7 +237,7 @@
     
       /* Team Name */
       .team-name {
-          font-size: 3vw;
+          font-size: min(3vw, 4vh);
           margin-bottom: 1rem;
           text-transform: uppercase;
           color: #2d3e50;


### PR DESCRIPTION
## Summary
- tweak scoreboard CSS so content scales relative to viewport height
- update basic scoreboard style to also use min() for font sizes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68441964ea88832db2022daa9223bebc