### PR TITLE
Fix modal position under navigation

### DIFF
--- a/leggtillag.html
+++ b/leggtillag.html
@@ -210,9 +210,9 @@
       .modal.desktop .modal-content {
         right: 0;
         left: auto;
-        top: var(--offset-top, 0);
+        top: 0; /* Position directly below nav */
         transform: none;
-        height: calc(100% - var(--offset-top, 0));
+        height: 100%;
         border-radius: 0;
       }
     }


### PR DESCRIPTION
## Summary
- fix CSS so the add team/referee modals appear directly beneath the navigation bar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684465606da4832dad8a030a40224047