### PR TITLE
Fix team fetch and default forms

### DIFF
--- a/leggtillag.html
+++ b/leggtillag.html
@@ -477,6 +477,11 @@
           option.value = division.name;
           divisionDropdown.appendChild(option);
         });
+        // Velg første divisjon automatisk dersom den finnes
+        if (divisions.length > 0) {
+          divisionDropdown.selectedIndex = 1; // hopp over "Velg divisjon"
+          hentOgVisLag();
+        }
       } catch (error) {
         console.error('Feil ved henting av divisjoner:', error);
       }
@@ -513,6 +518,9 @@ async function populateDivisionsCheckboxes() {
 document.addEventListener('DOMContentLoaded', () => {
   populateTeamsDropdown();           // eksisterende
   populateDivisionsCheckboxes();     // nye funksjonen
+  // Vis skjemaene for å legge til lag og dommere med en gang
+  openTeamForm();
+  openRefereeForm();
 });
 
     async function populateDivisionsDropdown() {


### PR DESCRIPTION
## Summary
- auto-select first division in team admin page and fetch teams
- open team and referee forms by default when visiting the page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844713bf504832d8936e1d7f55973ce