### PR TITLE
Add right-side team form

### DIFF
--- a/leggtillag.html
+++ b/leggtillag.html
@@ -123,9 +123,32 @@
   height: calc(100% - var(--offset-top, 0));
 }
 
-.modal.desktop .modal-content {
-  pointer-events: auto;
-}
+  .modal.desktop .modal-content {
+    pointer-events: auto;
+  }
+
+  /* Sidebar form for teams */
+  .team-form-sidebar {
+    display: none;
+    position: fixed;
+    top: var(--offset-top, 0);
+    right: 0;
+    width: 300px;
+    max-width: 90%;
+    height: calc(100% - var(--offset-top, 0));
+    background: #fff;
+    padding: 20px;
+    box-shadow: -2px 0 5px rgba(0,0,0,0.1);
+    overflow-y: auto;
+    z-index: 2600;
+  }
+  .team-form-sidebar .close-sidebar {
+    position: absolute;
+    top: 8px;
+    right: 12px;
+    font-size: 22px;
+    cursor: pointer;
+  }
 
 /* Close-knapp */
 .modal-content .close {
@@ -291,18 +314,16 @@
   </aside>
 
   <main>
-<!-- Team Popup -->
-<div id="teamPopup" class="modal">
-  <div class="modal-content">
-    <span class="close" onclick="document.getElementById('teamPopup').style.display='none'">&times;</span>
-    <form id="addTeamForm">
-      <label for="teamName">Team name:</label>
-      <input type="text" id="teamName" name="teamName" placeholder="Skriv lagnavn"><br>
-      <label for="spillerliste">Playerlist:</label>
-      <textarea id="spillerliste" rows="5" placeholder="Type in playernames, one per line" name="spillerliste"></textarea>
-      <button id="saveTeamBtn" onclick="saveTeam()" type="button">Add team</button>
-    </form>
-  </div>
+<div id="teamSidebar" class="team-form-sidebar">
+  <span class="close-sidebar" onclick="closeTeamForm()">&times;</span>
+  <form id="addTeamForm">
+    <label for="teamName">Team name:</label>
+    <input type="text" id="teamName" name="teamName" placeholder="Skriv lagnavn"><br>
+    <label for="spillerliste">Playerlist:</label>
+    <textarea id="spillerliste" rows="5" placeholder="Type in playernames, one per line" name="spillerliste"></textarea>
+    <button id="saveTeamBtn" onclick="saveTeam()" type="button">Add team</button>
+  </form>
+</div>
 
 
 <!-- Referee Form Popup -->
@@ -436,16 +457,19 @@
           }
         });
       }
-      const modal = document.getElementById('teamPopup');
+      const sidebar = document.getElementById('teamSidebar');
       if(window.innerWidth >= 768){
-        modal.classList.add('desktop');
-        applyModalOffset(modal);
+        applyModalOffset(sidebar);
       } else {
-        modal.classList.remove('desktop');
-        modal.style.removeProperty('--offset-top');
+        sidebar.style.removeProperty('--offset-top');
       }
-      modal.style.display = 'block';
-    }
+  sidebar.style.display = 'block';
+}
+
+ function closeTeamForm(){
+   const sidebar = document.getElementById('teamSidebar');
+   if(sidebar) sidebar.style.display = 'none';
+ }
     
     async function populateDivisionDropdown() {
       try {
@@ -608,7 +632,7 @@ document.addEventListener('DOMContentLoaded', () => {
         : teamsRef.add(lagData);
 
       p.then(() => {
-          document.getElementById('teamPopup').style.display = 'none';
+          closeTeamForm();
           editingTeamId = null;
           hentOgVisLag();
         })


### PR DESCRIPTION
## Summary
- replace popup for adding teams with a right sidebar
- show and hide sidebar with new open/close functions
- style sidebar form

## Testing
- `pytest`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844733a1754832d8b23acb17ba68e90