### PR TITLE
Bug fix for adding teams or referees per tab

### DIFF
--- a/leggtillag.html
+++ b/leggtillag.html
@@ -547,9 +547,6 @@ async function populateDivisionsCheckboxes() {
 document.addEventListener('DOMContentLoaded', () => {
   populateTeamsDropdown();           // eksisterende
   populateDivisionsCheckboxes();     // nye funksjonen
-  // Vis skjemaene for å legge til lag og dommere med en gang
-  openTeamForm();
-  openRefereeForm();
 });
 
     async function populateDivisionsDropdown() {
@@ -710,6 +707,14 @@ document.addEventListener('DOMContentLoaded', () => {
       document.getElementById(id).classList.add('active');
       document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
       if(btn) btn.classList.add('active');
+
+      // Close opposite form when switching tabs
+      if(id === 'teams') {
+        document.getElementById('refereeForm').style.display = 'none';
+      } else if(id === 'refs') {
+        const sidebar = document.getElementById('teamSidebar');
+        if(sidebar) sidebar.style.display = 'none';
+      }
     }
 
 function hentDommere() {


### PR DESCRIPTION
## Summary
- prevent forms from auto-opening when leggtillag.html loads
- close the opposite form when switching between Teams and Referees tabs

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_684482f81808832da1b2cb1d1b5a2941