### PR TITLE
Add Firestore feedback form

### DIFF
--- a/feedback.html
+++ b/feedback.html
@@ -8,10 +8,39 @@
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <style>
     body { font-family: 'Poppins', sans-serif; }
+    .modal { display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.4); justify-content: center; align-items: center; }
+    .modal-content { background: #fff; padding: 1.5rem; border-radius: 10px; text-align: center; }
   </style>
+  <script src="https://www.gstatic.com/firebasejs/8.2.0/firebase-app.js"></script>
+  <script src="firebaseConfig.js"></script>
+  <script src="https://www.gstatic.com/firebasejs/8.2.0/firebase-firestore.js"></script>
   <script>
+    firebase.initializeApp(firebaseConfig);
+    const db = firebase.firestore();
+
+    function showConfirmation() {
+      const modal = document.getElementById('feedbackModal');
+      modal.style.display = 'flex';
+      setTimeout(() => { modal.style.display = 'none'; }, 2000);
+    }
+
     function sendFeedback() {
-      alert('Takk for din tilbakemelding!');
+      const name = document.getElementById('name').value;
+      const email = document.getElementById('email').value;
+      const message = document.getElementById('message').value;
+      db.collection('feedback').add({
+        name,
+        email,
+        message,
+        timestamp: firebase.firestore.FieldValue.serverTimestamp()
+      }).then(() => {
+        showConfirmation();
+        document.getElementById('name').value = '';
+        document.getElementById('email').value = '';
+        document.getElementById('message').value = '';
+      }).catch((err) => {
+        console.error('Error submitting feedback:', err);
+      });
     }
   </script>
 </head>
@@ -37,5 +66,10 @@
       <button type="submit" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">Send inn</button>
     </form>
   </main>
+  <div id="feedbackModal" class="modal">
+    <div class="modal-content">
+      <p>Takk for din tilbakemelding!</p>
+    </div>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- wire up Firestore in feedback page
- save feedback submission to new `feedback` collection
- show submission confirmation in a modal dialog

## Testing
- `npm test` *(fails: cannot find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684483a86cf4832d92f0271d1fdf0b61