### PR TITLE
Show team form by default

### DIFF
--- a/leggtillag.html
+++ b/leggtillag.html
@@ -547,6 +547,7 @@ async function populateDivisionsCheckboxes() {
 document.addEventListener('DOMContentLoaded', () => {
   populateTeamsDropdown();           // eksisterende
   populateDivisionsCheckboxes();     // nye funksjonen
+  openTeamForm();
 });
 
     async function populateDivisionsDropdown() {
@@ -708,12 +709,13 @@ document.addEventListener('DOMContentLoaded', () => {
       document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
       if(btn) btn.classList.add('active');
 
-      // Close opposite form when switching tabs
       if(id === 'teams') {
         document.getElementById('refereeForm').style.display = 'none';
+        openTeamForm();
       } else if(id === 'refs') {
         const sidebar = document.getElementById('teamSidebar');
         if(sidebar) sidebar.style.display = 'none';
+        openRefereeForm();
       }
     }
 


### PR DESCRIPTION
## Summary
- display team form on page load
- switch between team and referee forms as tabs change

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684485187270832d9671f7aee3df3ce2