### PR TITLE
Add home links to FAQ and feedback pages

### DIFF
--- a/feedback.html
+++ b/feedback.html
@@ -46,7 +46,9 @@
 </head>
 <body class="font-[Poppins,sans-serif] bg-gray-100 text-gray-800">
   <header class="bg-gray-900 py-8 text-center">
-    <img src="logo.png" alt="Simple Scores Logo" class="mx-auto h-48">
+    <a href="index.html">
+      <img src="logo.png" alt="Simple Scores Logo" class="mx-auto h-48">
+    </a>
   </header>
   <main class="max-w-md mx-auto my-8 p-6 bg-white rounded-lg shadow">
     <h1 class="text-2xl font-bold mb-6 text-center">Gi tilbakemelding</h1>
@@ -65,6 +67,9 @@
       </div>
       <button type="submit" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">Send inn</button>
     </form>
+    <div class="text-center mt-6">
+      <button onclick="window.location.href='index.html'">Tilbake til forsiden</button>
+    </div>
   </main>
   <div id="feedbackModal" class="modal">
     <div class="modal-content">

--- a/qanda.html
+++ b/qanda.html
@@ -46,6 +46,7 @@
 </head>
 <body>
   <header>
+    <a href="index.html"><img src="logo.png" alt="Simple Scores Logo" style="height:80px"></a>
     <h1>Q&amp;A – Spørsmål og svar</h1>
   </header>
   <main>
@@ -66,6 +67,9 @@
       <div class="faq-answer">
         Besøk vår <a href="faq.html">FAQ</a> eller send oss en melding på <a href="feedback.html">tilbakemeldingsskjemaet</a>.
       </div>
+    </div>
+    <div style="text-align:center; margin-top:20px;">
+      <button onclick="window.location.href='index.html'">Tilbake til forsiden</button>
     </div>
   </main>
 </body>


### PR DESCRIPTION
## Summary
- add clickable logo linking to index on Q&A and feedback pages
- provide a "Tilbake til forsiden" button on both pages

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448850f694832d9263892fe53a52ea