### PR TITLE
Fix format.html double load

### DIFF
--- a/format.html
+++ b/format.html
@@ -880,7 +880,6 @@ async function visFaseData(faseNummer) {
             }
         }
 
-        visAlleFaserData();
 
         async function hentAlleLag() {
             let lagListe = [];


### PR DESCRIPTION
## Summary
- remove immediate `visAlleFaserData` call so formats aren't inserted twice

## Testing
- `npm test` *(fails: Could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684489de1c40832db87fd4a9bd0a5a18