### PR TITLE
Add top scorer page

### DIFF
--- a/dommerdetaljer.html
+++ b/dommerdetaljer.html
@@ -37,6 +37,7 @@
     <li><a href="lagoversikt.html" class="nav-link"><i class="fa-solid fa-users"></i><span>Lagoversikt</span></a></li>
     <li><a href="dommere.html" class="nav-link-active"><i class="fa-solid fa-gavel"></i><span>Dommere</span></a></li>
     <li><a href="tabell.html" class="nav-link"><i class="fa-solid fa-table-list"></i><span>Tabell</span></a></li>
+    <li><a href="toppscorer.html" class="nav-link"><i class="fa-solid fa-ranking-star"></i><span>Toppscorer</span></a></li>
   </ul>
 </nav>
 

--- a/dommere.html
+++ b/dommere.html
@@ -69,6 +69,7 @@
     <li><a href="lagoversikt.html" class="nav-link"><i class="fa-solid fa-users"></i><span>Lagoversikt</span></a></li>
     <li><a href="dommere.html" class="nav-link-active"><i class="fa-solid fa-gavel"></i><span>Dommere</span></a></li>
     <li><a href="tabell.html" class="nav-link"><i class="fa-solid fa-table-list"></i><span>Tabell</span></a></li>
+    <li><a href="toppscorer.html" class="nav-link"><i class="fa-solid fa-ranking-star"></i><span>Toppscorer</span></a></li>
   </ul>
 </nav>
 

--- a/kampdetaljer.html
+++ b/kampdetaljer.html
@@ -208,6 +208,7 @@
     <li><a href="lagoversikt.html" class="nav-link"><i class="fa-solid fa-users"></i><span>Lagoversikt</span></a></li>
     <li><a href="dommere.html" class="nav-link"><i class="fa-solid fa-gavel"></i><span>Dommere</span></a></li>
     <li><a href="tabell.html" class="nav-link"><i class="fa-solid fa-table-list"></i><span>Tabell</span></a></li>
+    <li><a href="toppscorer.html" class="nav-link"><i class="fa-solid fa-ranking-star"></i><span>Toppscorer</span></a></li>
   </ul>
 </nav>
 

--- a/kampliste.html
+++ b/kampliste.html
@@ -195,6 +195,7 @@
     <li><a href="lagoversikt.html" class="nav-link"><i class="fa-solid fa-users"></i><span>Lagoversikt</span></a></li>
     <li><a href="dommere.html" class="nav-link"><i class="fa-solid fa-gavel"></i><span>Dommere</span></a></li>
     <li><a href="tabell.html" class="nav-link"><i class="fa-solid fa-table-list"></i><span>Tabell</span></a></li>
+    <li><a href="toppscorer.html" class="nav-link"><i class="fa-solid fa-ranking-star"></i><span>Toppscorer</span></a></li>
   </ul>
 </nav>
 

--- a/lagdetaljer.html
+++ b/lagdetaljer.html
@@ -104,6 +104,7 @@
     <li><a href="lagoversikt.html" class="nav-link-active"><i class="fa-solid fa-users"></i><span>Lagoversikt</span></a></li>
     <li><a href="dommere.html" class="nav-link"><i class="fa-solid fa-gavel"></i><span>Dommere</span></a></li>
     <li><a href="tabell.html" class="nav-link"><i class="fa-solid fa-table-list"></i><span>Tabell</span></a></li>
+    <li><a href="toppscorer.html" class="nav-link"><i class="fa-solid fa-ranking-star"></i><span>Toppscorer</span></a></li>
   </ul>
 </nav>
 

--- a/lagoversikt.html
+++ b/lagoversikt.html
@@ -69,6 +69,7 @@
     <li><a href="lagoversikt.html" class="nav-link-active"><i class="fa-solid fa-users"></i><span>Lagoversikt</span></a></li>
     <li><a href="dommere.html" class="nav-link"><i class="fa-solid fa-gavel"></i><span>Dommere</span></a></li>
     <li><a href="tabell.html" class="nav-link"><i class="fa-solid fa-table-list"></i><span>Tabell</span></a></li>
+    <li><a href="toppscorer.html" class="nav-link"><i class="fa-solid fa-ranking-star"></i><span>Toppscorer</span></a></li>
   </ul>
 </nav>
 

--- a/tabell.html
+++ b/tabell.html
@@ -334,6 +334,7 @@
     <li><a href="lagoversikt.html" class="nav-link"><i class="fa-solid fa-users"></i><span>Lagoversikt</span></a></li>
     <li><a href="dommere.html" class="nav-link"><i class="fa-solid fa-gavel"></i><span>Dommere</span></a></li>
     <li><a href="tabell.html" class="nav-link-active"><i class="fa-solid fa-table-list"></i><span>Tabell</span></a></li>
+    <li><a href="toppscorer.html" class="nav-link"><i class="fa-solid fa-ranking-star"></i><span>Toppscorer</span></a></li>
   </ul>
 </nav>
 

--- a/toppscorer.html
+++ b/toppscorer.html
@@ -15,8 +15,31 @@
         <div class="logo-title">
             <img src="logo.png" alt="Simple Scores Logo" class="logo">
         </div>
-        <button onclick="window.location.href='publikum.html'">Hjem</button>
     </header>
+
+    <nav>
+      <!-- SKJUL SJEKKBOXEN SELV -->
+      <input type="checkbox" id="menu-toggle" />
+
+      <!-- ÉT ENESTE HAMBURGER‐IKON her -->
+      <label for="menu-toggle" id="menu-icon">
+        <span></span>
+        <span></span>
+        <span></span>
+      </label>
+
+      <!-- Selve menyen -->
+      <ul id="menu">
+        <li><a href="publikum.html" class="nav-link"><i class="fa-solid fa-house"></i><span>Hjem</span></a></li>
+        <li><a href="login.html" class="nav-link"><i class="fa-solid fa-user"></i><span>Admin</span></a></li>
+        <li><a href="turnering.html" class="nav-link"><i class="fa-solid fa-circle-info"></i><span>Turneringsdetaljer</span></a></li>
+        <li><a href="kampliste.html" class="nav-link"><i class="fa-solid fa-futbol"></i><span>Kamper</span></a></li>
+        <li><a href="lagoversikt.html" class="nav-link"><i class="fa-solid fa-users"></i><span>Lagoversikt</span></a></li>
+        <li><a href="dommere.html" class="nav-link"><i class="fa-solid fa-gavel"></i><span>Dommere</span></a></li>
+        <li><a href="tabell.html" class="nav-link"><i class="fa-solid fa-table-list"></i><span>Tabell</span></a></li>
+        <li><a href="toppscorer.html" class="nav-link-active"><i class="fa-solid fa-ranking-star"></i><span>Toppscorer</span></a></li>
+      </ul>
+    </nav>
     <main>
         <h2>Toppscorerliste</h2>
         <ol id="scorerList" class="scorers-list"></ol>
@@ -27,10 +50,24 @@
 <script>
 firebase.initializeApp(firebaseConfig);
 const db = firebase.firestore();
-const tournamentId = new URLSearchParams(window.location.search).get('tournamentid');
+const params = new URLSearchParams(window.location.search);
+const tournamentId = params.get('tournamentid');
 if (!tournamentId) {
     window.location.href = 'publikum.html';
 }
+
+function updateLinks() {
+    document.querySelectorAll('a').forEach(link => {
+        const href = link.getAttribute('href');
+        if (href && !href.startsWith('http') && !href.startsWith('mailto:') && !href.startsWith('#')) {
+            const sep = href.includes('?') ? '&' : '?';
+            if (!href.includes('tournamentid=')) {
+                link.setAttribute('href', href + sep + 'tournamentid=' + tournamentId);
+            }
+        }
+    });
+}
+
 async function fetchTopScorers() {
     try {
         const matchesSnap = await db.collection('turneringer').doc(tournamentId).collection('kamper').get();
@@ -57,7 +94,10 @@ async function fetchTopScorers() {
         document.getElementById('scorerList').innerHTML = '<li>En feil oppstod.</li>';
     }
 }
-document.addEventListener('DOMContentLoaded', fetchTopScorers);
+document.addEventListener('DOMContentLoaded', () => {
+    updateLinks();
+    fetchTopScorers();
+});
 </script>
 </body>
 </html>

--- a/toppscorer.html
+++ b/toppscorer.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="no">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Toppscorere</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="style.css">
+    <script src="https://www.gstatic.com/firebasejs/8.2.0/firebase-app.js"></script>
+    <script src="firebaseConfig.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/8.2.0/firebase-firestore.js"></script>
+</head>
+<body>
+    <header>
+        <div class="logo-title">
+            <img src="logo.png" alt="Simple Scores Logo" class="logo">
+        </div>
+        <button onclick="window.location.href='publikum.html'">Hjem</button>
+    </header>
+    <main>
+        <h2>Toppscorerliste</h2>
+        <ol id="scorerList" class="scorers-list"></ol>
+    </main>
+    <footer>
+        <p>&copy; 2024 Turneringer. Alle rettigheter reservert.</p>
+    </footer>
+<script>
+firebase.initializeApp(firebaseConfig);
+const db = firebase.firestore();
+const tournamentId = new URLSearchParams(window.location.search).get('tournamentid');
+if (!tournamentId) {
+    window.location.href = 'publikum.html';
+}
+async function fetchTopScorers() {
+    try {
+        const matchesSnap = await db.collection('turneringer').doc(tournamentId).collection('kamper').get();
+        const scorerCounts = {};
+        for (const matchDoc of matchesSnap.docs) {
+            const goalsSnap = await matchDoc.ref.collection('goals').get();
+            goalsSnap.forEach(g => {
+                const player = g.data().spiller || 'Ukjent';
+                if (player === 'ikke-definert' || player === 'selvmål') return;
+                scorerCounts[player] = (scorerCounts[player] || 0) + 1;
+            });
+        }
+        const sorted = Object.entries(scorerCounts).sort((a,b) => b[1]-a[1]);
+        const list = document.getElementById('scorerList');
+        if (sorted.length === 0) {
+            list.innerHTML = '<li>Ingen mål registrert.</li>';
+            return;
+        }
+        list.innerHTML = sorted.map(([player,count], idx) => `
+            <li><span class="player-name">${idx+1}. ${player}</span> - <span class="goal-details">${count} mål</span></li>
+        `).join('');
+    } catch(err){
+        console.error('Feil ved henting av toppscorere:', err);
+        document.getElementById('scorerList').innerHTML = '<li>En feil oppstod.</li>';
+    }
+}
+document.addEventListener('DOMContentLoaded', fetchTopScorers);
+</script>
+</body>
+</html>

--- a/turnering.html
+++ b/turnering.html
@@ -135,6 +135,7 @@
     <li><a href="lagoversikt.html" class="nav-link"><i class="fa-solid fa-users"></i><span>Lagoversikt</span></a></li>
     <li><a href="dommere.html" class="nav-link"><i class="fa-solid fa-gavel"></i><span>Dommere</span></a></li>
     <li><a href="tabell.html" class="nav-link"><i class="fa-solid fa-table-list"></i><span>Tabell</span></a></li>
+    <li><a href="toppscorer.html" class="nav-link"><i class="fa-solid fa-ranking-star"></i><span>Toppscorer</span></a></li>
   </ul>
 </nav>
 


### PR DESCRIPTION
## Summary
- add a public `toppscorer.html` page for viewing tournament top scorers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68456063e520832db36afc7d06bcb093