### PR TITLE
Add card logging and display features

### DIFF
--- a/kampdetaljer.html
+++ b/kampdetaljer.html
@@ -248,7 +248,13 @@
                 <li>Laster...</li>
               </ul>
             </div>
-      
+            <div class="cards-section">
+              <h3>Hendelser:</h3>
+              <ul class="cards-list" id="cardsList">
+                <li>Laster...</li>
+              </ul>
+            </div>
+
             <a href="kampliste.html" class="details-button">Tilbake til Kamper</a>
           </div>
         </div>
@@ -316,6 +322,7 @@ const rtdb = firebase.database();
         // Elementer
         const kampDetails = document.getElementById('kampDetails');
         const scorersList = document.getElementById('scorersList');
+        const cardsList   = document.getElementById('cardsList');
         const scoreElement = document.getElementById('score');
         const team1Element = document.getElementById('team1');
         const team2Element = document.getElementById('team2');
@@ -428,6 +435,10 @@ async function initializePage() {
 
     // Hent og vis tabell for valgt divisjon/fase
     await fetchPhaseData(kampDivisjon, kampFase, kampSegment);
+
+    // Sett opp lyttere for scorere og hendelser
+    fetchScorers(kampDocRef, data.hjemmelag, data.bortelag);
+    setupCardListener(kampDocRef, data.hjemmelag, data.bortelag);
 
     // Hvis kampen er startet, koble sanntids-lytter
     if (data.status === 'startet') {
@@ -1211,6 +1222,30 @@ tabButtons.forEach(btn => {
             currentTimeoutTeam = null;
             }
         }, 1000);
+        }
+
+        function setupCardListener(kampRef, hjemmelag, bortelag) {
+            kampRef.collection('cards').orderBy('time').onSnapshot(snapshot => {
+                if (snapshot.empty) {
+                    cardsList.innerHTML = '<li>Ingen hendelser.</li>';
+                    return;
+                }
+                let html = '';
+                snapshot.forEach(doc => {
+                    const data = doc.data();
+                    const spiller = data.spiller || 'Ukjent spiller';
+                    const time = data.time || '00:00';
+                    const teamSide = data.team || 'Ukjent Lag';
+                    const type = data.type || '';
+                    let teamName = teamSide.toLowerCase() === 'hjemme' ? hjemmelag : bortelag;
+                    let typeText = type;
+                    if (type === 'yellow') typeText = 'Gult kort';
+                    else if (type === 'red') typeText = 'Rødt kort';
+                    else if (type === 'penalty') typeText = `Utvisning ${data.duration || 120}s`;
+                    html += `<li><div class="player-info"><span class="player-name">${spiller}</span><span class="goal-details">${time}' - ${teamName} - ${typeText}</span></div></li>`;
+                });
+                cardsList.innerHTML = html;
+            });
         }
 
 

--- a/scoreboard.css
+++ b/scoreboard.css
@@ -414,7 +414,14 @@
           color: white;
           cursor: pointer;
       }
-      .penalty-btn:hover { background: #0056b3; }
+.penalty-btn:hover { background: #0056b3; }
+
+.yellow-button { background-color: #f6e05e; color: #2d3e50; }
+.red-button { background-color: #e53e3e; color: white; }
+.penalty-button { background-color: #ed8936; color: white; }
+.yellow-button:hover { background-color: #ecc94b; }
+.red-button:hover { background-color: #c53030; }
+.penalty-button:hover { background-color: #dd6b20; }
     
 @media (max-width: 480px) {
     .timer, .score {

--- a/scoreboard.html
+++ b/scoreboard.html
@@ -36,10 +36,13 @@
                         <div class="team-name" id="hjemmelagNavn">Lag 1</div>
                         <div class="score-controls">
                             <div class="adjust-buttons">
-                                <button class="score-button" onclick="openPlayerModal('hjemme')">+</button>
+                                <button class="score-button" onclick="openPlayerModal('hjemme','goal')">+</button>
                                 <button class="score-button" onclick="adjustScore('hjemmeScore', -1, 'hjemme')">-</button>
                             </div>
                             <button class="time-button" onclick="startTimeout('hjemme')">Timeout</button>
+                            <button class="time-button yellow-button" style="display:none;" onclick="openPlayerModal('hjemme','yellow')">Gult kort</button>
+                            <button class="time-button red-button" style="display:none;" onclick="openPlayerModal('hjemme','red')">Rødt kort</button>
+                            <button class="time-button penalty-button" style="display:none;" onclick="openPlayerModal('hjemme','penalty')">2&nbsp;min</button>
                         </div>
                     </div>
                     <div class="score-section" id="borteSection">
@@ -47,10 +50,13 @@
                         <div class="team-name" id="bortelagNavn">Lag 2</div>
                         <div class="score-controls">
                             <div class="adjust-buttons">
-                                <button class="score-button" onclick="openPlayerModal('borte')">+</button>
+                                <button class="score-button" onclick="openPlayerModal('borte','goal')">+</button>
                                 <button class="score-button" onclick="adjustScore('borteScore', -1, 'borte')">-</button>
                             </div>
                             <button class="time-button" onclick="startTimeout('borte')">Timeout</button>
+                            <button class="time-button yellow-button" style="display:none;" onclick="openPlayerModal('borte','yellow')">Gult kort</button>
+                            <button class="time-button red-button" style="display:none;" onclick="openPlayerModal('borte','red')">Rødt kort</button>
+                            <button class="time-button penalty-button" style="display:none;" onclick="openPlayerModal('borte','penalty')">2&nbsp;min</button>
                         </div>
                     </div>
                 </div>
@@ -83,7 +89,7 @@
     <div id="playerModal" class="modal">
         <div class="modal-content">
             <span class="close" onclick="closeModal()">&times;</span>
-            <h2>Velg spiller som scoret</h2>
+            <h2 id="modalTitle">Velg spiller</h2>
             <ul id="playerList" class="player-list"></ul>
         </div>
     </div>
@@ -216,6 +222,9 @@ let pauseDuration;   // Pauselengde, satt fra innstillingene
         let storedTimeLeft; // For å lagre tiden før timeout
         let originalTimeLeft; // For å lagre tiden før timeout start
         let logGoalScorersEnabled = true; // Kan deaktiveres via innstillinger
+        let logYellowCardsEnabled = false;
+        let logRedCardsEnabled    = false;
+        let logPenaltiesEnabled   = false;
         // Global variabel for kampens fase – "utslag" for utslagskamper
 let matchPhase;
 
@@ -294,6 +303,9 @@ async function hentInnstillinger(division) {
             logGoalScorersEnabled =
                 settings.logGoalScorers === undefined ? true
                                                      : Boolean(settings.logGoalScorers);
+            logYellowCardsEnabled = Boolean(settings.logYellowCards);
+            logRedCardsEnabled    = Boolean(settings.logRedCards);
+            logPenaltiesEnabled   = Boolean(settings.logPenalties);
             console.log("pauseDuration satt til:", pauseDuration);
 
         } else {
@@ -304,6 +316,9 @@ async function hentInnstillinger(division) {
             timeBegin       = 900;
             timeoutDuration = 30;
             pauseDuration   = 60;
+            logYellowCardsEnabled = false;
+            logRedCardsEnabled    = false;
+            logPenaltiesEnabled   = false;
         }
     } catch (error) {
         console.error('Feil ved henting av innstillinger:', error);
@@ -313,6 +328,9 @@ async function hentInnstillinger(division) {
         timeBegin       = 900;
         timeoutDuration = 30;
         pauseDuration   = 60;
+        logYellowCardsEnabled = false;
+        logRedCardsEnabled    = false;
+        logPenaltiesEnabled   = false;
     }
 
     // --- OPPDATER UI HER ---
@@ -324,6 +342,16 @@ async function hentInnstillinger(division) {
 
     // Periodetekst
     document.getElementById('period').textContent = `${currentPeriod}. omgang`;
+
+    document.querySelectorAll('.yellow-button').forEach(btn => {
+        btn.style.display = logYellowCardsEnabled ? 'block' : 'none';
+    });
+    document.querySelectorAll('.red-button').forEach(btn => {
+        btn.style.display = logRedCardsEnabled ? 'block' : 'none';
+    });
+    document.querySelectorAll('.penalty-button').forEach(btn => {
+        btn.style.display = logPenaltiesEnabled ? 'block' : 'none';
+    });
 }
 
 
@@ -1416,7 +1444,7 @@ async function updateTeamStatsAfterReset(hjemmelag, bortelag, hjemmeScore, borte
 
 
 
-        async function logGoalAndUpdateScore(spiller, team) {
+async function logGoalAndUpdateScore(spiller, team) {
     const minutes = Math.floor(timeLeft / 60);
     const seconds = timeLeft % 60;
     const formattedTime = `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
@@ -1499,38 +1527,82 @@ async function updateTeamStatsAfterReset(hjemmelag, bortelag, hjemmeScore, borte
     }
 }
 
+async function logCard(spiller, team, type) {
+    const minutes = Math.floor(timeLeft / 60);
+    const seconds = timeLeft % 60;
+    const formattedTime = `${minutes.toString().padStart(2,'0')}:${seconds.toString().padStart(2,'0')}`;
+
+    const cardData = {
+        spiller: spiller,
+        team: team,
+        type: type,
+        time: formattedTime,
+        period: currentPeriod
+    };
+    if (type === 'penalty') {
+        cardData.duration = 120;
+    }
+
+    try {
+        const kampRef = db.collection('turneringer').doc(turneringId)
+                           .collection('kamper').doc(kampId);
+        await kampRef.collection('cards').add(cardData);
+        console.log('Kort registrert');
+    } catch (error) {
+        console.error('Feil ved registrering av kort:', error);
+    }
+}
+
 
 
 
         // Funksjon for å åpne spiller-popup
-        async function openPlayerModal(team) {
-            if (!logGoalScorersEnabled) {
+        let currentEventType = 'goal';
+        async function openPlayerModal(team, type = 'goal') {
+            currentEventType = type;
+            if (type === 'goal' && !logGoalScorersEnabled) {
                 await logGoalAndUpdateScore('ikke-definert', team);
                 return;
             }
 
+            const titleEl = document.getElementById('modalTitle');
             const playerListElement = document.getElementById('playerList');
-            playerListElement.innerHTML = ''; // Tøm listen først
+            playerListElement.innerHTML = '';
 
+            let teamName = team === 'hjemme'
+                ? document.getElementById('hjemmelagNavn').textContent
+                : document.getElementById('bortelagNavn').textContent;
 
-            let teamName = team === 'hjemme' ? document.getElementById('hjemmelagNavn').textContent : document.getElementById('bortelagNavn').textContent;
+            switch (type) {
+                case 'yellow':
+                    titleEl.textContent = 'Velg spiller med gult kort';
+                    break;
+                case 'red':
+                    titleEl.textContent = 'Velg spiller med rødt kort';
+                    break;
+                case 'penalty':
+                    titleEl.textContent = 'Velg spiller for 2 minutters utvisning';
+                    break;
+                default:
+                    titleEl.textContent = 'Velg spiller som scoret';
+            }
 
-            // Legg til forhåndsdefinerte valg: "Ikke definert" og "Selvmål"
-            const predefinedOptions = [
-                { label: 'Ikke definert', value: 'ikke-definert' },
-                { label: 'Selvmål', value: 'selvmål' }
-            ];
+            if (type === 'goal') {
+                const predefinedOptions = [
+                    { label: 'Ikke definert', value: 'ikke-definert' },
+                    { label: 'Selvmål', value: 'selvmål' }
+                ];
 
-            predefinedOptions.forEach(option => {
-                const listItem = document.createElement('li');
-                listItem.textContent = option.label;
-                listItem.onclick = function() {
-                    // Logg målet som en spesialhendelse (ikke definert eller selvmål)
-                    logGoalAndUpdateScore(option.value, team);
-                    closeModal();
-                };
-                playerListElement.appendChild(listItem);
-            });
+                predefinedOptions.forEach(option => {
+                    const listItem = document.createElement('li');
+                    listItem.textContent = option.label;
+                    listItem.onclick = function() {
+                        logGoalAndUpdateScore(option.value, team);
+                        closeModal();
+                    };
+                    playerListElement.appendChild(listItem);
+                });
+            }
 
             // Hent spillere for laget fra Firebase
             db.collection('turneringer').doc(turneringId)
@@ -1538,14 +1610,17 @@ async function updateTeamStatsAfterReset(hjemmelag, bortelag, hjemmeScore, borte
                 .then(snapshot => {
                     if (!snapshot.empty) {
                         snapshot.forEach(doc => {
-                            const spillerData = doc.data().spillere || []; // Anta at spillere er et array i lag-dokumentet
+                            const spillerData = doc.data().spillere || [];
                             spillerData.forEach(spiller => {
                                 const listItem = document.createElement('li');
                                 listItem.textContent = spiller;
                                 listItem.onclick = function() {
-                                    // Logg mål til Firebase
-                                    logGoalAndUpdateScore(spiller, team);
-                                    alert(spiller + ' scoret!');
+                                    if (currentEventType === 'goal') {
+                                        logGoalAndUpdateScore(spiller, team);
+                                        alert(spiller + ' scoret!');
+                                    } else {
+                                        logCard(spiller, team, currentEventType);
+                                    }
                                     closeModal();
                                 };
                                 playerListElement.appendChild(listItem);

--- a/settings.html
+++ b/settings.html
@@ -127,6 +127,18 @@
             <label for="logGoalScorers">Logg målscorere</label>
             <input type="checkbox" id="logGoalScorers" checked>
         </div>
+        <div class="form-group">
+            <label for="logYellowCards">Logg gule kort</label>
+            <input type="checkbox" id="logYellowCards">
+        </div>
+        <div class="form-group">
+            <label for="logRedCards">Logg røde kort</label>
+            <input type="checkbox" id="logRedCards">
+        </div>
+        <div class="form-group">
+            <label for="logPenalties">Logg tidsutvisning (sekund)</label>
+            <input type="checkbox" id="logPenalties">
+        </div>
         
 
         <button onclick="saveSettings()">Lagre innstillinger</button>
@@ -204,6 +216,9 @@
     const timeoutDuration = document.getElementById('timeoutDuration').value;
     const pauseDuration = document.getElementById('pauseDuration').value;  // Ny variabel
     const logGoalScorers = document.getElementById('logGoalScorers').checked;
+    const logYellowCards = document.getElementById('logYellowCards').checked;
+    const logRedCards    = document.getElementById('logRedCards').checked;
+    const logPenalties   = document.getElementById('logPenalties').checked;
 
     // Lagre innstillingene i Firestore under turneringen
     db.collection('turneringer').doc(turneringId)
@@ -213,7 +228,10 @@
             numPeriods: parseInt(numPeriods),
             timeoutDuration: parseInt(timeoutDuration),
             pauseDuration: parseInt(pauseDuration),  // Lagre den nye innstillingen
-            logGoalScorers: logGoalScorers
+            logGoalScorers: logGoalScorers,
+            logYellowCards: logYellowCards,
+            logRedCards:    logRedCards,
+            logPenalties:   logPenalties
       })
       .then(() => {
           document.getElementById('settingsSaved').style.display = 'block';

--- a/style.css
+++ b/style.css
@@ -803,6 +803,46 @@ footer {
     padding: 40px;
 }
 
+/* Cards Section - samme stil som scorers */
+.cards-section {
+    background-color: white;
+    border: 1px solid #ddd;
+    border-radius: 10px;
+    padding: 20px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    margin-bottom: 20px;
+    max-width: 800px;
+    margin-left: auto;
+    margin-right: auto;
+    text-align: left;
+}
+
+.cards-section h3 {
+    margin-top: 0;
+    color: #2d3e50;
+    font-size: 2rem;
+}
+
+.cards-list {
+    list-style-type: none;
+    padding-left: 0;
+}
+
+.cards-list li {
+    background-color: #f9f9f9;
+    margin-bottom: 10px;
+    padding: 15px;
+    border-radius: 5px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    transition: background-color 0.3s;
+}
+
+.cards-list li:hover {
+    background-color: #e9ecef;
+}
+
 /* Individuell tournament card */
 .turnering {
     width: 100%;


### PR DESCRIPTION
## Summary
- add toggles for yellow/red cards and penalties in settings
- allow scoreboard to log yellow, red and 2 minute penalties
- store card events in Firestore and display them in match details
- style new buttons and event lists

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68456153fc10832dbd9556d37d32aa7a