### PR TITLE
Fix phase loading in format.html

### DIFF
--- a/format.html
+++ b/format.html
@@ -349,10 +349,11 @@ async function populateDivisionDropdown() {
     });
 
     if (divisions.length > 0) {
-      // Sett første divisjon som valgt...
+      // Sett første divisjon som valgt
       dropdown.value = divisions[0].name;
-      // ...og utløs onchange umiddelbart så vi henter lagrede formater med en gang
-      dropdown.dispatchEvent(new Event('change'));
+      // Hent alle lagrede faser direkte slik at alt innhold vises umiddelbart
+      loadedPhaseKeys.clear();
+      await visAlleFaserData();
     }
   } catch (error) {
     console.error('Feil ved henting av divisjoner:', error);
@@ -541,7 +542,7 @@ document.getElementById('divisionDropdown')
         table.appendChild(tbody);
         segmentDiv.appendChild(table);
     }
-    populateGDropdowns(fasesjekk, segmentIndex);
+    await populateGDropdowns(fasesjekk, segmentIndex);
 }
 
 


### PR DESCRIPTION
## Summary
- load phases directly after populating divisions
- wait for group dropdowns to populate before finishing table creation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68457265dcf8832d9acd58777fe2c13a