### PR TITLE
Fix popup styling and schedule loading

### DIFF
--- a/kampoppsett.html
+++ b/kampoppsett.html
@@ -5,6 +5,7 @@
         <title>Kampoppsett</title>
         <meta charset="utf-8">
         <link rel="stylesheet" type="text/css" href="./admin.css">
+        <link rel="stylesheet" type="text/css" href="./style.css">
         <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
         <style>
 .body {
@@ -452,7 +453,10 @@
 }
      
 const params = new URLSearchParams(window.location.search);
-    const turneringId = params.get('id');
+let turneringId = params.get('id') || sessionStorage.getItem('turneringId');
+if (turneringId) {
+  sessionStorage.setItem('turneringId', turneringId);
+}
      
 
   document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- load the same global styles used elsewhere so popup styling is applied
- store tournament id in session storage so schedule generation and loading work across the page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845738fd9c8832d841fbf7387c1a1f9