### PR TITLE
Fix show password button overlay

### DIFF
--- a/login.html
+++ b/login.html
@@ -97,7 +97,7 @@
             color: #2d3748;
         }
 
-        .login-section button {
+        .login-section button:not(.toggle-btn) {
             width: 100%;
             padding: 12px;
             margin-top: 20px;
@@ -110,7 +110,7 @@
             transition: background 0.3s ease;
         }
 
-        .login-section button:hover {
+        .login-section button:not(.toggle-btn):hover {
             background: linear-gradient(45deg, #48bb78, #434190);
         }
 


### PR DESCRIPTION
## Summary
- restrict `.login-section` button styling so it doesn't apply to the password toggle

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684574a272f0832db1c51d10620d5946