### PR TITLE
Load division segments concurrently

### DIFF
--- a/format.html
+++ b/format.html
@@ -814,9 +814,13 @@ async function visFaseData(faseNummer) {
             if (isLoadingPhases) return;
             isLoadingPhases = true;
             loadedPhaseKeys.clear();
+
+            const promises = [];
             for (let faseNummer = 1; faseNummer <= 3; faseNummer++) {
-                await visFaseData(faseNummer);
+                promises.push(visFaseData(faseNummer));
             }
+            await Promise.all(promises);
+
             isLoadingPhases = false;
         }
 


### PR DESCRIPTION
## Summary
- load all phase data in parallel when changing division

## Testing
- `npm test` *(fails: missing package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684596a5f914832daf95b761dcfb3153