### PR TITLE
Fix logo layout for kampoppsett

### DIFF
--- a/kampoppsett.html
+++ b/kampoppsett.html
@@ -4,8 +4,8 @@
   <script src="https://cdn.tailwindcss.com"></script>
         <title>Kampoppsett</title>
         <meta charset="utf-8">
-        <link rel="stylesheet" type="text/css" href="./admin.css">
         <link rel="stylesheet" type="text/css" href="./style.css">
+        <link rel="stylesheet" type="text/css" href="./admin.css">
         <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
         <style>
 .body {


### PR DESCRIPTION
## Summary
- swap CSS include order so `kampoppsett.html` uses the same header styling as `format.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845970db5f0832d96298a066337ee20