### PR TITLE
Fix schedule wizard crash with missing dates

### DIFF
--- a/kampoppsett.html
+++ b/kampoppsett.html
@@ -2592,7 +2592,13 @@ function planMatchOnCourt(match, settings, baner) {
 
   // Initialiser intern tilstand første gang
   if (!window.schedulingState) {
-    const dateQueue = Object.entries(dateTimes).sort(([a], [b]) => a.localeCompare(b));
+    const dateQueue = Object.entries(dateTimes)
+      .sort(([a], [b]) => a.localeCompare(b));
+
+    if (dateQueue.length === 0) {
+      throw new Error('Ingen dato/tid er definert for kampoppsettet');
+    }
+
     const courtNext = {};
     const banerMap = {};
     baner.forEach(b => {


### PR DESCRIPTION
## Summary
- handle empty `dateTimes` list during schedule generation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684597beb780832da6b06332aa846046