### PR TITLE
Fix header style for kampoppsett

### DIFF
--- a/kampoppsett.html
+++ b/kampoppsett.html
@@ -4,7 +4,6 @@
   <script src="https://cdn.tailwindcss.com"></script>
         <title>Kampoppsett</title>
         <meta charset="utf-8">
-        <link rel="stylesheet" type="text/css" href="./style.css">
         <link rel="stylesheet" type="text/css" href="./admin.css">
         <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
         <style>


### PR DESCRIPTION
## Summary
- ensure `kampoppsett.html` uses the same header styling as other admin pages by removing the extra `style.css` stylesheet

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845997dcd7c832d9bec8d390872e62c