### PR TITLE
Fix popup stacking order

### DIFF
--- a/scoreboard.css
+++ b/scoreboard.css
@@ -291,7 +291,7 @@
       .modal {
           display: none;
           position: fixed;
-          z-index: 1;
+          z-index: 3001;
           left: 0;
           top: 0;
           width: 100%;

--- a/style.css
+++ b/style.css
@@ -897,7 +897,7 @@ footer {
     background-color: #ffffff;
     border-radius: 15px;
     box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
-    z-index: 1000;
+    z-index: 3001;
     max-width: 90%;
 }
 
@@ -926,7 +926,7 @@ footer {
     width: 100%;
     height: 100%;
     background: rgba(0, 0, 0, 0.5);
-    z-index: 999;
+    z-index: 3000;
 }
 
 .popup-overlay.active {


### PR DESCRIPTION
## Summary
- ensure popups display above wizard elements by raising their z-index
- raise scoreboard modal z-index as well

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68459f92c31c832db87d136368b155c9