### PR TITLE
Improve scheduling error handling

### DIFF
--- a/kampoppsett.html
+++ b/kampoppsett.html
@@ -2546,6 +2546,36 @@ async function finishWizard() {
     const matchTiming    = document.querySelector('input[name="wizard_matchTiming"]:checked').value;
     const baner          = await hentOgOpprettBaner();
 
+    if (!baner || baner.length === 0) {
+      console.error('[finishWizard] Ingen baner funnet');
+      alert('Ingen baner funnet for turneringen. Legg til baner før du genererer kampoppsett.');
+      return;
+    }
+
+    // --- Rask sanity-check på om det finnes nok tid totalt ---
+    const minutesDiff = (s, e) => {
+      const sMs = new Date(`1970-01-01T${s}:00`).getTime();
+      const eMs = new Date(`1970-01-01T${e}:00`).getTime();
+      return (eMs - sMs) / 60000;
+    };
+    const totalCourtMinutes = baner.length * Object.values(wizardDateTimes)
+      .reduce((sum, dt) => sum + minutesDiff(dt.startTime, dt.endTime), 0);
+    const totalMatchMinutes = Object.entries(alleMatches)
+      .reduce((sum, [div, fases]) => {
+        const dur = divisionTimes[div] || 0;
+        const count = Object.values(fases).flat().length;
+        return sum + count * (dur + tidMellomKamper);
+      }, 0);
+    if (totalMatchMinutes > totalCourtMinutes) {
+      console.error('[finishWizard] For lite tid for kampene', {
+        totalMatchMinutes,
+        totalCourtMinutes
+      });
+      alert('Ikke nok tilgjengelig tid på banene for alle kampene. ' +
+            'Kontroller antall baner, varighet og tidspunkter.');
+      return;
+    }
+
     // 4) Sett globalSchedulingSettings for generateSchedule
     window.globalSchedulingSettings = {
       divisions:        Object.keys(divisionTimes),
@@ -2723,7 +2753,14 @@ function planMatchOnCourt(match, settings, baner) {
         chosen = { court, ...next, ts };
       }
     }
-    if (!chosen) throw new Error('Ingen ledige slots igjen for planlegging');
+    if (!chosen) {
+      console.error('[planMatchOnCourt] Ingen ledige slots', {
+        match,
+        courtNext: state.courtNext,
+        dateQueue: state.dateQueue
+      });
+      throw new Error('Ingen ledige slots igjen for planlegging');
+    }
 
     // 2) Sjekk lagenes tilgjengelighet
     startTs = chosen.ts;


### PR DESCRIPTION
## Summary
- provide early exit in `finishWizard` when no courts are found
- log detailed state before throwing "Ingen ledige slots" error
- add sanity check for available time

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845ad796f64832d90e5396890727768