### PR TITLE
Fix scheduling when dateTimes missing info

### DIFF
--- a/kampoppsett.html
+++ b/kampoppsett.html
@@ -2652,7 +2652,9 @@ function planMatchOnCourt(match, settings, baner) {
 
   // Initialiser intern tilstand første gang
   if (!window.schedulingState) {
-    const dateQueue = Object.entries(dateTimes)
+    const dateQueue = Object
+      .entries(dateTimes)
+      .filter(([d, t]) => t && t.startTime && t.endTime)
       .sort(([a], [b]) => a.localeCompare(b));
 
     if (dateQueue.length === 0) {
@@ -2680,8 +2682,16 @@ function planMatchOnCourt(match, settings, baner) {
       const [d, slot] = state.dateQueue[i];
       const start = avail[d]?.startTime || slot.startTime;
       const end   = avail[d]?.endTime   || slot.endTime;
+
+      // Hopp hvis start eller slutt mangler
+      if (!start || !end) continue;
+
       const startTs = toTimestamp(d, start);
       const endTs   = toTimestamp(d, end);
+
+      // Hopp ugyldige datoer
+      if (isNaN(startTs) || isNaN(endTs)) continue;
+
       const ts = Math.max(minTs, startTs);
       if (ts + durMin * 60 * 1000 <= endTs) {
         return { dateIndex: i, time: new Date(ts).toTimeString().slice(0,5) };


### PR DESCRIPTION
## Summary
- handle empty or invalid start/end times when building date queue
- skip invalid slots in `findNextSlot`

## Testing
- `pre-commit` *(fails: no tests provided)*

------
https://chatgpt.com/codex/tasks/task_e_6845b0e518a0832da4fd73a639764af4