### PR TITLE
Fix scheduling when years >4 digits

### DIFF
--- a/kampoppsett.html
+++ b/kampoppsett.html
@@ -2646,13 +2646,17 @@ function planMatchOnCourt(match, settings, baner) {
   const dateTimes = window.globalSchedulingSettings.dateTimes;
   
   const toTimestamp = (dateStr, timeStr) => {
-    return new Date(`${dateStr}T${timeStr}:00`).getTime();
+    const [y, m, d] = dateStr.split('-').map(Number);
+    const [hh, mm]  = timeStr.split(':').map(Number);
+    return new Date(y, m - 1, d, hh, mm).getTime();
   };
 
 
   // Initialiser intern tilstand første gang
   if (!window.schedulingState) {
-    const dateQueue = Object.entries(dateTimes)
+    const dateQueue = Object
+      .entries(dateTimes)
+      .filter(([d, t]) => t && t.startTime && t.endTime)
       .sort(([a], [b]) => a.localeCompare(b));
 
     if (dateQueue.length === 0) {
@@ -2680,8 +2684,16 @@ function planMatchOnCourt(match, settings, baner) {
       const [d, slot] = state.dateQueue[i];
       const start = avail[d]?.startTime || slot.startTime;
       const end   = avail[d]?.endTime   || slot.endTime;
+
+      // Hopp hvis start eller slutt mangler
+      if (!start || !end) continue;
+
       const startTs = toTimestamp(d, start);
       const endTs   = toTimestamp(d, end);
+
+      // Hopp ugyldige datoer
+      if (isNaN(startTs) || isNaN(endTs)) continue;
+
       const ts = Math.max(minTs, startTs);
       if (ts + durMin * 60 * 1000 <= endTs) {
         return { dateIndex: i, time: new Date(ts).toTimeString().slice(0,5) };


### PR DESCRIPTION
## Summary
- parse schedule timestamps with numeric year handling

## Testing
- `pre-commit` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_6845b0e518a0832da4fd73a639764af4