### PR TITLE
Fix manual tournament redirection

### DIFF
--- a/OpprettTurnering.html
+++ b/OpprettTurnering.html
@@ -393,7 +393,8 @@ auth.onAuthStateChanged((user) => {
     location,
     organizer,
     divisions,
-    published: false   // slå publisering av som default
+    published: false,   // slå publisering av som default
+    manual: false
 };
 
 

--- a/manualTurnering.html
+++ b/manualTurnering.html
@@ -196,7 +196,7 @@
         return;
       }
       try{
-        const docRef = await db.collection('turneringer').add({tournamentName:name, location:place, dates, organizer, published:false});
+        const docRef = await db.collection('turneringer').add({tournamentName:name, location:place, dates, organizer, published:false, manual:true});
         for(const match of matches){
           await db.collection('turneringer').doc(docRef.id).collection('kamper').add(match);
         }

--- a/nyTurnering.html
+++ b/nyTurnering.html
@@ -131,9 +131,13 @@
 
             turneringDiv.appendChild(actionsDiv);
 
-            // Klikk på kortet åpner detaljsiden for turneringen ved å sende turnerings-ID-en i querystring
+            // Klikk på kortet åpner riktig redigeringsside basert på om turneringen er manuell eller ikke
             turneringDiv.addEventListener('click', function() {
-              window.location.href = "leggtillag.html?id=" + doc.id;
+              if (turnering.manual) {
+                window.location.href = 'manualMatches.html?id=' + doc.id;
+              } else {
+                window.location.href = 'leggtillag.html?id=' + doc.id;
+              }
             });
 
             turneringListe.appendChild(turneringDiv);
@@ -166,7 +170,11 @@
         turneringDiv.className = 'turnering';
         turneringDiv.textContent = turnering.tournamentName;
         turneringDiv.addEventListener('click', () => {
-          window.location.href = 'leggtillag.html?id=' + turneringRef.id;
+          if (turnering.manual) {
+            window.location.href = 'manualMatches.html?id=' + turneringRef.id;
+          } else {
+            window.location.href = 'leggtillag.html?id=' + turneringRef.id;
+          }
         });
         coArrangorListe.appendChild(turneringDiv);
       });


### PR DESCRIPTION
## Summary
- mark created manual tournaments with a `manual` flag
- mark automatically created tournaments as `manual: false`
- open manual tournaments in the manual matches page from `nyTurnering`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845cd42c994832d890c6c2c1c388cfb