### PR TITLE
Add popup styling rules for admin pages

### DIFF
--- a/admin.css
+++ b/admin.css
@@ -291,6 +291,64 @@ select {
     cursor: pointer;
 }
 
+/* Popup Styling */
+.popup {
+    display: none;
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 450px;
+    padding: 25px;
+    background-color: #ffffff;
+    border-radius: 15px;
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
+    z-index: 3001;
+    max-width: 90%;
+}
+
+.popup.active {
+    display: block;
+    animation: popup-fade-in 0.3s ease-in-out;
+}
+
+@keyframes popup-fade-in {
+    from {
+        opacity: 0;
+        transform: translate(-50%, -60%);
+    }
+    to {
+        opacity: 1;
+        transform: translate(-50%, -50%);
+    }
+}
+
+/* Background Overlay */
+.popup-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 3000;
+}
+
+.popup-overlay.active {
+    display: block;
+    animation: overlay-fade-in 0.3s ease-in-out;
+}
+
+@keyframes overlay-fade-in {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
 /* Ensure readable text in the division dropdown */
 #divisionDropdown,
 #divisionDropdown option {


### PR DESCRIPTION
## Summary
- add base CSS for popup components used in `kampoppsett.html` and other admin pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845ce796708832da0eab1aefda8de96