### PR TITLE
Improve match fetching with debugging

### DIFF
--- a/kamper.html
+++ b/kamper.html
@@ -230,7 +230,7 @@
     });
 
     const params = new URLSearchParams(window.location.search);
-    const turneringId = params.get('id');
+    const turneringId = params.get('id') || params.get('tournamentid');
 
     document.addEventListener('DOMContentLoaded', () => {
       if (!turneringId) {
@@ -253,15 +253,24 @@
   upcoming.innerHTML = '';
   previous.innerHTML = '';
 
-  const snapshot = await db.collection('turneringer')
-    .doc(turneringId).collection('kamper')
-    .orderBy('starttid', 'asc').get();
+  try {
+    const snapshot = await db.collection('turneringer')
+      .doc(turneringId)
+      .collection('kamper')
+      .orderBy('starttid', 'asc')
+      .get();
 
-  snapshot.forEach(doc => {
-    const k = doc.data();
-    const startDate = k.starttid?.toDate
-      ? k.starttid.toDate()
-      : new Date(k.starttid);
+    if (snapshot.empty) {
+      console.debug('Ingen kamper funnet i Firestore');
+      upcoming.innerHTML = '<p>Ingen kamper funnet.</p>';
+      return;
+    }
+
+    snapshot.forEach(doc => {
+      const k = doc.data();
+      const startDate = k.starttid?.toDate
+        ? k.starttid.toDate()
+        : new Date(k.starttid);
     const formattedTime = startDate.toLocaleString('no-NO', {
       day: 'numeric', month: 'long', hour: '2-digit', minute: '2-digit'
     });
@@ -306,12 +315,17 @@
     card.append(info, btnContainer);
 
     // Plasser i riktig seksjon
-    if (k.status === 'startet' || k.status === 'ferdig') {
-      previous.appendChild(card);
-    } else {
-      upcoming.appendChild(card);
-    }
-  });
+      if (k.status === 'startet' || k.status === 'ferdig') {
+        previous.appendChild(card);
+      } else {
+        upcoming.appendChild(card);
+      }
+    });
+    console.debug('Hentet', snapshot.size, 'kamper fra Firestore');
+  } catch (err) {
+    console.error('Feil ved henting av kamper:', err);
+    upcoming.innerHTML = '<p>En feil oppstod ved henting av kamper.</p>';
+  }
 }
 
 

--- a/kampliste.html
+++ b/kampliste.html
@@ -241,7 +241,8 @@
     const toggleFilters = document.getElementById('toggleFilters');
 
     let allMatches = [];
-    const tournamentId = new URLSearchParams(window.location.search).get('tournamentid');
+    const params = new URLSearchParams(window.location.search);
+    const tournamentId = params.get('tournamentid') || params.get('id');
 
   // Dersom tournamentid mangler, omdiriger til opprettingssiden (nyTurnering.html)
   if (!tournamentId) {
@@ -277,37 +278,58 @@
     });
 
     async function fetchMatches() {
-      const snap = await firestore.collection('turneringer').doc(tournamentId).collection('kamper').get();
-      allMatches = snap.docs.map(doc => {
-        const d     = doc.data();
-        const start = d.starttid.toDate();
-        const end   = d.sluttid?.toDate();
-        return {
-          id: doc.id,
-          hjemmelag: d.hjemmelag,
-          bortelag: d.bortelag,
-          dateStr: start.toLocaleDateString('no-NO',{day:'numeric',month:'short'}),
-          timeStr: start.toLocaleTimeString('no-NO',{hour:'2-digit',minute:'2-digit'}),
-          endTimeStr: end ? end.toLocaleTimeString('no-NO',{hour:'2-digit',minute:'2-digit'}) : '',
-          ts: start.getTime(),
-          score1: d.hjemmelagScore,
-          score2: d.bortelagScore,
-          status: d.status || '',
-          referees: Array.isArray(d.dommere) ? d.dommere : []
-        };
-      }).sort((a,b) => a.ts - b.ts);
-      populateTeamFilter(); applyFilters();
+      try {
+        const snap = await firestore
+          .collection('turneringer')
+          .doc(tournamentId)
+          .collection('kamper')
+          .get();
+        if (snap.empty) {
+          console.debug('Ingen kamper funnet i Firestore');
+          container.innerHTML = '<p>Ingen kamper funnet.</p>';
+          return;
+        }
+        allMatches = snap.docs.map(doc => {
+          const d = doc.data();
+          const start = d.starttid ? (d.starttid.toDate ? d.starttid.toDate() : new Date(d.starttid)) : new Date(NaN);
+          const end = d.sluttid ? (d.sluttid.toDate ? d.sluttid.toDate() : new Date(d.sluttid)) : null;
+          return {
+            id: doc.id,
+            hjemmelag: d.hjemmelag,
+            bortelag: d.bortelag,
+            dateStr: !isNaN(start) ? start.toLocaleDateString('no-NO', {day:'numeric',month:'short'}) : 'Ukjent',
+            timeStr: !isNaN(start) ? start.toLocaleTimeString('no-NO', {hour:'2-digit',minute:'2-digit'}) : 'Ukjent',
+            endTimeStr: end && !isNaN(end) ? end.toLocaleTimeString('no-NO', {hour:'2-digit',minute:'2-digit'}) : '',
+            ts: start.getTime(),
+            score1: d.hjemmelagScore,
+            score2: d.bortelagScore,
+            status: d.status || '',
+            referees: Array.isArray(d.dommere) ? d.dommere : []
+          };
+        }).sort((a,b) => a.ts - b.ts);
+        console.debug('Hentet', allMatches.length, 'kamper fra Firestore');
+        populateTeamFilter();
+        applyFilters();
+      } catch (error) {
+        console.error('Feil ved henting av kamper:', error);
+        container.innerHTML = '<p>En feil oppstod ved henting av kamper.</p>';
+      }
     }
 
     function subscribeLiveUpdates() {
-      rtdb.ref(`games/${tournamentId}/kamper`).on('value', snap => {
-        const data = snap.val() || {};
-        allMatches.forEach(m => {
-          const live = data[m.id] || {};
-          m.currentPeriod = live.currentPeriod ?? null;
-          m.remainingTime = live.remainingTime ?? null;
-        }); renderMatches(filterMatches());
-      });
+      try {
+        rtdb.ref(`games/${tournamentId}/kamper`).on('value', snap => {
+          const data = snap.val() || {};
+          allMatches.forEach(m => {
+            const live = data[m.id] || {};
+            m.currentPeriod = live.currentPeriod ?? null;
+            m.remainingTime = live.remainingTime ?? null;
+          });
+          renderMatches(filterMatches());
+        });
+      } catch (error) {
+        console.error('Feil ved henting av live-data:', error);
+      }
     }
 
     function populateTeamFilter() {

--- a/manualMatches.html
+++ b/manualMatches.html
@@ -157,7 +157,7 @@
     });
 
     const params = new URLSearchParams(window.location.search);
-    const turneringId = params.get('id');
+    const turneringId = params.get('id') || params.get('tournamentid');
 
     let availableDates = [];
 
@@ -231,10 +231,21 @@
     async function hentKamper() {
       const container = document.getElementById('matches');
       container.innerHTML = '';
-      const snapshot = await db.collection('turneringer').doc(turneringId)
-        .collection('kamper').orderBy('starttid','asc').get();
-      snapshot.forEach(doc => {
-        const k = doc.data();
+      try {
+        const snapshot = await db.collection('turneringer')
+          .doc(turneringId)
+          .collection('kamper')
+          .orderBy('starttid','asc')
+          .get();
+
+        if (snapshot.empty) {
+          console.debug('Ingen kamper funnet i Firestore');
+          container.innerHTML = '<p>Ingen kamper funnet.</p>';
+          return;
+        }
+
+        snapshot.forEach(doc => {
+          const k = doc.data();
 
         let startDate = null;
         if (k.starttid) {
@@ -271,10 +282,15 @@
         resBtn.classList.add('result-btn');
         resBtn.textContent = 'Legg inn resultat';
         resBtn.onclick = () => openResultModal(doc.id, k.hjemmelag, k.bortelag);
-        btnContainer.append(sbBtn, resBtn);
-        card.append(info, btnContainer);
-        container.appendChild(card);
-      });
+          btnContainer.append(sbBtn, resBtn);
+          card.append(info, btnContainer);
+          container.appendChild(card);
+        });
+        console.debug('Hentet', snapshot.size, 'kamper fra Firestore');
+      } catch (err) {
+        console.error('Feil ved henting av kamper:', err);
+        container.innerHTML = '<p>En feil oppstod ved henting av kamper.</p>';
+      }
     }
 
     function gåTilScoreboard(kampId) {


### PR DESCRIPTION
## Summary
- ensure tournament ID fallback uses both `id` and `tournamentid`
- show message if no matches are stored in Firebase
- add console logging for easier troubleshooting

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d3d91748832d90c813fedf5c3187