### PR TITLE
Ensure matches load after auth

### DIFF
--- a/kampoppsett.html
+++ b/kampoppsett.html
@@ -487,14 +487,29 @@
 
             const auth = firebase.auth();
 
+            let domReady = false;
+            let loggedIn = false;
+
+            function startIfReady() {
+                if (domReady && loggedIn) {
+                    initKampoppsett();
+                }
+            }
+
+            document.addEventListener('DOMContentLoaded', () => {
+                domReady = true;
+                startIfReady();
+            });
+
             auth.onAuthStateChanged((user) => {
-        if (user) {
-                const email = user.email;
-                document.getElementById('mail').innerHTML = email;
-        } else {
-        // Ingen bruker er logget inn, redirect til innloggingssiden
-        window.location.href = 'login.html';
-        }
+                if (user) {
+                    const email = user.email;
+                    document.getElementById('mail').innerHTML = email;
+                    loggedIn = true;
+                    startIfReady();
+                } else {
+                    window.location.href = 'login.html';
+                }
             });
         function loggut() {
     auth.signOut().then(() => {
@@ -2922,8 +2937,11 @@ async function loadSavedSchedule() {
 window.baner = [];
 
 // Når DOM er klar: hent turneringsdata, innstillinger, datoer, baner OG kamper
-document.addEventListener('DOMContentLoaded', async () => {
-  console.log('DOMContentLoaded: init kampoppsett');
+let pageInitialized = false;
+async function initKampoppsett() {
+  if (pageInitialized) return;
+  pageInitialized = true;
+  console.log('initKampoppsett: starter');
   window.savedWizardSettings = loadWizardSettings();
   await fetchTurneringData();      // → window.turneringData.dates
   await initializeSettings();      // → window.globalSchedulingSettings
@@ -2950,7 +2968,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   // Til slutt: hent og vis lagrede kamper
   await loadSavedSchedule();       // nå vil renderScheduleUI finne baner og kamper
-});
+}
 
 function buildPhaseQueue(matchRounds) {
   const phaseQueue = [];


### PR DESCRIPTION
## Summary
- load kampoppsett only when both DOM is ready and user is logged in

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845d70c579c832d9e7d195fbceaeadd