### PR TITLE
Fix lane query selector bug

### DIFF
--- a/kampoppsett.html
+++ b/kampoppsett.html
@@ -3668,7 +3668,7 @@ function renderMatches(scheduledMatches) {
     const dateDiv = container.querySelector(
       `.date-container[data-date="${dateStr}"]`
     );
-    const laneDiv = dateDiv.querySelector(`.bane-tabell#${m.bane}`);
+    const laneDiv = dateDiv.querySelector(`.bane-tabell[id="${m.bane}"]`);
 
     const card = document.createElement('div');
     card.className = m.faseType === 'pause' ? 'pause-kort' : 'kamp-kort';


### PR DESCRIPTION
## Summary
- fix invalid selector when rendering matches in kampoppsett.html

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68469fa8a2c4832da2054510258ddd88