### PR TITLE
Enable editing slides via dedicated editor

### DIFF
--- a/format.html
+++ b/format.html
@@ -74,6 +74,7 @@
         <button class="meny-ikon" id="meny-knapp" aria-label="Åpne meny" aria-expanded="false" aria-controls="meny"></button>
         <ul id="meny">
             <li><a href="slideshow.html">Slideshow</a></li>
+        <li><a href="slideshowEditor.html">Slideshow Editor</a></li>
             <li><a href="instillinger.html">Instillinger</a></li>
             <li><a href="leggtillag.html">Legg til lag</a></li>
             <li><a href="format.html">Format</a></li>

--- a/instillinger.html
+++ b/instillinger.html
@@ -100,6 +100,7 @@
     <button class="meny-ikon" id="meny-knapp" aria-label="Åpne meny" aria-expanded="false" aria-controls="meny"></button>
     <ul id="meny">
       <li><a href="slideshow.html">Slideshow</a></li>
+        <li><a href="slideshowEditor.html">Slideshow Editor</a></li>
       <li><a href="instillinger.html">Innstillinger</a></li>
       <li><a href="leggtillag.html">Legg til lag</a></li>
       <li><a href="format.html">Format</a></li>

--- a/kamper.html
+++ b/kamper.html
@@ -182,6 +182,7 @@
     <button class="meny-ikon" id="meny-knapp" aria-label="Åpne meny" aria-expanded="false" aria-controls="meny"></button>
     <ul id="meny">
       <li><a href="slideshow.html">Slideshow</a></li>
+        <li><a href="slideshowEditor.html">Slideshow Editor</a></li>
       <li><a href="instillinger.html">Instillinger</a></li>
       <li><a href="leggtillag.html">Legg til lag</a></li>
       <li><a href="format.html">Format</a></li>

--- a/kampoppsett.html
+++ b/kampoppsett.html
@@ -307,6 +307,7 @@
             <button class="meny-ikon" id="meny-knapp" aria-label="Åpne meny" aria-expanded="false" aria-controls="meny"></button>
             <ul id="meny">
                 <li><a href="slideshow.html">Slideshow</a></li>
+        <li><a href="slideshowEditor.html">Slideshow Editor</a></li>
                 <li><a href="instillinger.html">Instillinger</a></li>
                 <li><a href="leggtillag.html">Legg til lag</a></li>
                 <li><a href="format.html">Format</a></li>

--- a/leggtillag.html
+++ b/leggtillag.html
@@ -241,6 +241,7 @@
     <button class="meny-ikon" id="meny-knapp" aria-label="Åpne meny" aria-expanded="false" aria-controls="meny"></button>
     <ul id="meny">
       <li><a href="slideshow.html">Slideshow</a></li>
+        <li><a href="slideshowEditor.html">Slideshow Editor</a></li>
       <li><a href="instillinger.html">Instillinger</a></li>
       <li><a href="leggtillag.html">Legg til lag</a></li>
       <li><a href="format.html">Format</a></li>

--- a/settings.html
+++ b/settings.html
@@ -86,6 +86,7 @@
         <button class="meny-ikon" id="meny-knapp" aria-label="Åpne meny" aria-expanded="false" aria-controls="meny"></button>
         <ul id="meny">
             <li><a href="slideshow.html">Slideshow</a></li>
+        <li><a href="slideshowEditor.html">Slideshow Editor</a></li>
             <li><a href="instillinger.html">Instillinger</a></li>
             <li><a href="legg til lag.html">Legg til lag</a></li>
             <li><a href="format.html">Format</a></li>

--- a/slideshow.html
+++ b/slideshow.html
@@ -382,6 +382,7 @@
     <button class="meny-ikon" id="meny-knapp" aria-label="Åpne meny" aria-expanded="false" aria-controls="meny"></button>
     <ul id="meny">
         <li><a href="slideshow.html">Slideshow</a></li>
+        <li><a href="slideshowEditor.html">Slideshow Editor</a></li>
         <li><a href="instillinger.html">Instillinger</a></li>
         <li><a href="leggtillag.html">Legg til lag</a></li>
         <li><a href="format.html">Format</a></li>
@@ -782,9 +783,12 @@ function showSlide(index) {
 
     // Åpne slide-konfigurasjons-popup
     function openSlideConfigPopup(slide = null) {
-      // Viderekoble til den dedikerte slideeditoren i stedet for
-      // å bruke det innebygde popup-vinduet.
-      const url = `slideshowEditor.html?id=${encodeURIComponent(turneringId)}`;
+      // Viderekoble til den dedikerte slideeditoren og send med eventuell
+      // slide-id slik at riktig slide kan redigeres der.
+      let url = `slideshowEditor.html?id=${encodeURIComponent(turneringId)}`;
+      if (slide && slide.id) {
+        url += `&slide=${encodeURIComponent(slide.id)}`;
+      }
       window.location.href = url;
     }
 

--- a/slideshowEditor.html
+++ b/slideshowEditor.html
@@ -383,6 +383,7 @@
     <button class="meny-ikon" id="meny-knapp" aria-label="Åpne meny" aria-expanded="false" aria-controls="meny"></button>
     <ul id="meny">
         <li><a href="slideshow.html">Slideshow</a></li>
+        <li><a href="slideshowEditor.html">Slideshow Editor</a></li>
         <li><a href="instillinger.html">Instillinger</a></li>
         <li><a href="leggtillag.html">Legg til lag</a></li>
         <li><a href="format.html">Format</a></li>
@@ -455,6 +456,7 @@
         // Hent turnerings-ID fra URL-querystring
     const params = new URLSearchParams(window.location.search);
     const turneringId = params.get('id');
+    const slideIdParam = params.get('slide');
 
     document.addEventListener('DOMContentLoaded', function() {
 
@@ -797,9 +799,11 @@ function showSlide(index) {
           }
           return { id: doc.id, ...d, elements: elems };
         });
-        if (slides.length > 0) {
-          renderSlidesOverview();
-        } else {
+        renderSlidesOverview();
+        if (slideIdParam) {
+          const s = slides.find(sl => sl.id === slideIdParam);
+          openSlideConfigPopup(s || null);
+        } else if (slides.length === 0) {
           openSlideConfigPopup();
         }
       }).catch(error => {


### PR DESCRIPTION
## Summary
- link to Slideshow Editor in navigation menus
- allow editing a specific slide from slideshow page
- parse slide parameter in Slideshow Editor and open relevant slide

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6846a08a5ff8832dbc4a42e893306839