### PR TITLE
Fix lane selection with spaces

### DIFF
--- a/kampoppsett.html
+++ b/kampoppsett.html
@@ -3668,7 +3668,12 @@ function renderMatches(scheduledMatches) {
     const dateDiv = container.querySelector(
       `.date-container[data-date="${dateStr}"]`
     );
-    const laneDiv = dateDiv.querySelector(`.bane-tabell[id="${m.bane}"]`);
+    // m.bane kan inneholde mellomrom eller andre tegn som gir ugyldig
+    // CSS-selektor. Bruk CSS.escape for å sikre at querySelector får
+    // et gyldig uttrykk.
+    const laneDiv = dateDiv.querySelector(
+      `.bane-tabell[id="${CSS.escape(m.bane)}"]`
+    );
 
     const card = document.createElement('div');
     card.className = m.faseType === 'pause' ? 'pause-kort' : 'kamp-kort';


### PR DESCRIPTION
## Summary
- handle court names containing spaces by escaping lane IDs

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6846a0dce990832dbd86249b4421650e