### PR TITLE
Fix Firestore match queries

### DIFF
--- a/kampoppsett.html
+++ b/kampoppsett.html
@@ -2888,6 +2888,7 @@ async function loadSavedSchedule() {
       .collection('turneringer')
       .doc(turneringId)
       .collection('kamper')
+      .orderBy('starttid', 'asc')
       .get();
     console.log('loadSavedSchedule: funnet', snapshot.size, 'kamper');
     if (snapshot.empty) {
@@ -4898,6 +4899,7 @@ async function slettBane(baneNavn) {
       .collection('turneringer')
       .doc(turneringId)
       .collection('kamper')
+      .orderBy('starttid', 'asc')
       .get();
     console.log('Antall kamper funnet:', kamperSnap.size);
 
@@ -4931,6 +4933,7 @@ async function hentKamperFraFirebase() {
             .collection("turneringer")
             .doc(turneringId)
             .collection("kamper")
+            .orderBy('starttid', 'asc')
             .get();
 
         const kamper = kamperSnapshot.docs.map(doc => doc.data());


### PR DESCRIPTION
## Summary
- fetch saved matches ordered by start time in `kampoppsett.html`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6846a2d683b4832d9b1929c7774d58ff