### PR TITLE
Remove Firebase orderBy usage

### DIFF
--- a/kamper.html
+++ b/kamper.html
@@ -256,9 +256,19 @@
 
   const snapshot = await db.collection('turneringer')
     .doc(turneringId).collection('kamper')
-    .orderBy('starttid', 'asc').get();
+    .get();
 
-  snapshot.forEach(doc => {
+  const docs = snapshot.docs.slice().sort((a, b) => {
+    const aDate = a.data().starttid?.toDate
+      ? a.data().starttid.toDate()
+      : new Date(a.data().starttid);
+    const bDate = b.data().starttid?.toDate
+      ? b.data().starttid.toDate()
+      : new Date(b.data().starttid);
+    return aDate - bDate;
+  });
+
+  docs.forEach(doc => {
     const k = doc.data();
     const startDate = k.starttid?.toDate
       ? k.starttid.toDate()

--- a/kampoppsett.html
+++ b/kampoppsett.html
@@ -2888,7 +2888,6 @@ async function loadSavedSchedule() {
       .collection('turneringer')
       .doc(turneringId)
       .collection('kamper')
-      .orderBy('starttid', 'asc')
       .get();
     console.log('loadSavedSchedule: funnet', snapshot.size, 'kamper');
     if (snapshot.empty) {
@@ -4899,11 +4898,14 @@ async function slettBane(baneNavn) {
       .collection('turneringer')
       .doc(turneringId)
       .collection('kamper')
-      .orderBy('starttid', 'asc')
       .get();
     console.log('Antall kamper funnet:', kamperSnap.size);
 
-    const matches = kamperSnap.docs.map(doc => {
+    const matches = kamperSnap.docs.slice().sort((a,b) => {
+      const aDate = a.data().starttid.toDate();
+      const bDate = b.data().starttid.toDate();
+      return aDate - bDate;
+    }).map(doc => {
       const d = doc.data();
       return {
         id:         doc.id,
@@ -4933,10 +4935,13 @@ async function hentKamperFraFirebase() {
             .collection("turneringer")
             .doc(turneringId)
             .collection("kamper")
-            .orderBy('starttid', 'asc')
             .get();
 
-        const kamper = kamperSnapshot.docs.map(doc => doc.data());
+        const kamper = kamperSnapshot.docs.slice().sort((a,b) => {
+            const aDate = a.data().starttid.toDate();
+            const bDate = b.data().starttid.toDate();
+            return aDate - bDate;
+        }).map(doc => ({ id: doc.id, ...doc.data() }));
 
         // Tøm eksisterende banecontainere
         const baneContainerElementer = document.querySelectorAll(".bane-container");

--- a/manualMatches.html
+++ b/manualMatches.html
@@ -232,8 +232,19 @@
       const container = document.getElementById('matches');
       container.innerHTML = '';
       const snapshot = await db.collection('turneringer').doc(turneringId)
-        .collection('kamper').orderBy('starttid','asc').get();
-      snapshot.forEach(doc => {
+        .collection('kamper').get();
+
+      const docs = snapshot.docs.slice().sort((a,b) => {
+        const aDate = a.data().starttid?.toDate
+          ? a.data().starttid.toDate()
+          : new Date(a.data().starttid);
+        const bDate = b.data().starttid?.toDate
+          ? b.data().starttid.toDate()
+          : new Date(b.data().starttid);
+        return aDate - bDate;
+      });
+
+      docs.forEach(doc => {
         const k = doc.data();
 
         let startDate = null;

--- a/scoreboard.html
+++ b/scoreboard.html
@@ -726,13 +726,22 @@ async function hentNesteKampPaBane(bane, starttid) {
       .doc(turneringId)
       .collection('kamper')
       .where('bane', '==', bane)
-      .orderBy('starttid')
       .get();
+
+    const docs = snap.docs.slice().sort((a, b) => {
+      const aDate = a.data().starttid?.toDate
+        ? a.data().starttid.toDate()
+        : new Date(a.data().starttid);
+      const bDate = b.data().starttid?.toDate
+        ? b.data().starttid.toDate()
+        : new Date(b.data().starttid);
+      return aDate - bDate;
+    });
 
     const startMs = starttid?.toDate ? starttid.toDate().getTime()
                                    : new Date(starttid).getTime();
     let next = null;
-    snap.forEach(doc => {
+    docs.forEach(doc => {
       const d = doc.data();
       const ts = d.starttid?.toDate ? d.starttid.toDate().getTime()
                                     : new Date(d.starttid).getTime();


### PR DESCRIPTION
## Summary
- drop Firestore `orderBy` calls for match lists
- sort match snapshots client-side after retrieval

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846a48ee89c832dbac52fad57703868