### PR TITLE
Fix loading schedule twice

### DIFF
--- a/kampoppsett.html
+++ b/kampoppsett.html
@@ -494,9 +494,6 @@
             function startIfReady() {
                 if (domReady && loggedIn) {
                     initKampoppsett();
-                    // Forsikre at lagrede kamper vises i UI selv om init
-                    // skulle feile eller returnere før visning
-                    hentOgVisKampoppsett().catch(console.error);
                 }
             }
 


### PR DESCRIPTION
## Summary
- stop calling `hentOgVisKampoppsett` during page startup

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_6846a8e47b58832daccaa6eec7d21c2f