### PR TITLE
Add console logs for troubleshooting match creation

### DIFF
--- a/manualMatches.html
+++ b/manualMatches.html
@@ -204,19 +204,30 @@
       const time  = document.getElementById('matchTime').value;
       const field = document.getElementById('matchField').value.trim();
       const div   = document.getElementById('matchDivision').value.trim();
+      console.log('addMatch called', { home, away, date, time, field, div });
       if (!home || !away || !date || !time) {
+        console.log('addMatch missing required fields', { home, away, date, time });
         alert('Fyll inn alle påkrevde felter');
         return;
       }
       const start = firebase.firestore.Timestamp.fromDate(new Date(`${date}T${time}`));
-      await db.collection('turneringer').doc(turneringId).collection('kamper').add({
-        hjemmelag: home,
-        bortelag: away,
-        starttid: start,
-        bane: field,
-        divisjon: div,
-        status: 'planlagt'
-      });
+      try {
+        const docRef = await db
+          .collection('turneringer')
+          .doc(turneringId)
+          .collection('kamper')
+          .add({
+            hjemmelag: home,
+            bortelag: away,
+            starttid: start,
+            bane: field,
+            divisjon: div,
+            status: 'planlagt'
+          });
+        console.log('Match added with ID:', docRef.id);
+      } catch (e) {
+        console.error('Error adding match:', e);
+      }
       document.getElementById('homeTeam').value = '';
       document.getElementById('awayTeam').value = '';
 

--- a/manualTurnering.html
+++ b/manualTurnering.html
@@ -141,8 +141,13 @@
       const away = document.getElementById('awayTeam').value.trim();
       const date = document.getElementById('matchDate').value;
       const time = document.getElementById('matchTime').value;
-      if(!home || !away || !date || !time) return alert('Fyll inn alle felt');
+      console.log('addMatch called', { home, away, date, time });
+      if(!home || !away || !date || !time){
+        console.log('addMatch missing required fields', { home, away, date, time });
+        return alert('Fyll inn alle felt');
+      }
       matches.push({hjemmelag:home,bortelag:away,dato:date,tidskode:time});
+      console.log('Current matches array:', matches);
       updateMatches();
       document.getElementById('homeTeam').value='';
       document.getElementById('awayTeam').value='';


### PR DESCRIPTION
## Summary
- add debugging logs to match creation on manual match/tournament pages

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6846c1f4cf44832d8833757ed412a831