### PR TITLE
Add yellow/red card and penalty tracking

### DIFF
--- a/scoreboard.css
+++ b/scoreboard.css
@@ -422,6 +422,36 @@
 .yellow-button:hover { background-color: #ecc94b; }
 .red-button:hover { background-color: #c53030; }
 .penalty-button:hover { background-color: #dd6b20; }
+
+/* Card and penalty displays */
+.card-display {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.25rem;
+    margin-top: 0.5rem;
+    font-size: 0.9rem;
+}
+
+.card {
+    padding: 2px 4px;
+    border-radius: 3px;
+    color: white;
+}
+
+.yellow-card { background-color: #f6e05e; color: #2d3e50; }
+.red-card { background-color: #e53e3e; color: #fff; }
+
+.penalty-display { margin-top: 0.5rem; text-align: center; }
+.penalty-item {
+    background-color: #ed8936;
+    color: white;
+    padding: 2px 4px;
+    border-radius: 3px;
+    margin: 2px 0;
+    display: inline-block;
+}
+.penalty-time { margin-left: 4px; }
     
 @media (max-width: 480px) {
     .timer, .score {

--- a/scoreboard.html
+++ b/scoreboard.html
@@ -44,6 +44,8 @@
                             <button class="time-button red-button" style="display:none;" onclick="openPlayerModal('hjemme','red')">Rødt kort</button>
                             <button class="time-button penalty-button" style="display:none;" onclick="openPlayerModal('hjemme','penalty')">2&nbsp;min</button>
                         </div>
+                        <div id="hjemmeCards" class="card-display"></div>
+                        <div id="hjemmePenalties" class="penalty-display"></div>
                     </div>
                     <div class="score-section" id="borteSection">
                         <div id="borteScore" class="score">0</div>
@@ -58,6 +60,8 @@
                             <button class="time-button red-button" style="display:none;" onclick="openPlayerModal('borte','red')">Rødt kort</button>
                             <button class="time-button penalty-button" style="display:none;" onclick="openPlayerModal('borte','penalty')">2&nbsp;min</button>
                         </div>
+                        <div id="borteCards" class="card-display"></div>
+                        <div id="bortePenalties" class="penalty-display"></div>
                     </div>
                 </div>
             </div>
@@ -229,6 +233,7 @@ let pauseDuration;   // Pauselengde, satt fra innstillingene
         let logYellowCardsEnabled = false;
         let logRedCardsEnabled    = false;
         let logPenaltiesEnabled   = false;
+        const activePenalties = { hjemme: [], borte: [] };
         // Global variabel for kampens fase – "utslag" for utslagskamper
 let matchPhase;
 
@@ -1564,9 +1569,54 @@ async function logCard(spiller, team, type) {
                            .collection('kamper').doc(kampId);
         await kampRef.collection('cards').add(cardData);
         console.log('Kort registrert');
+        updateCardUI(spiller, team, type);
     } catch (error) {
         console.error('Feil ved registrering av kort:', error);
     }
+}
+
+function updateCardUI(spiller, team, type) {
+    if (type === 'yellow') {
+        addCard(team, 'yellow-card', spiller);
+    } else if (type === 'red') {
+        addCard(team, 'red-card', spiller);
+    } else if (type === 'penalty') {
+        startPenaltyTimer(team, spiller);
+    }
+}
+
+function addCard(team, cardClass, spiller) {
+    const containerId = team === 'hjemme' ? 'hjemmeCards' : 'borteCards';
+    const container = document.getElementById(containerId);
+    const span = document.createElement('span');
+    span.className = `card ${cardClass}`;
+    span.textContent = spiller;
+    container.appendChild(span);
+}
+
+function startPenaltyTimer(team, spiller) {
+    const containerId = team === 'hjemme' ? 'hjemmePenalties' : 'bortePenalties';
+    const container = document.getElementById(containerId);
+    const item = document.createElement('div');
+    item.className = 'penalty-item';
+    item.textContent = spiller + ':';
+    const span = document.createElement('span');
+    span.className = 'penalty-time';
+    item.appendChild(span);
+    container.appendChild(item);
+
+    let remaining = 120;
+    span.textContent = formatTime(remaining);
+    const interval = setInterval(() => {
+        remaining--;
+        if (remaining <= 0) {
+            clearInterval(interval);
+            item.remove();
+        } else {
+            span.textContent = formatTime(remaining);
+        }
+    }, 1000);
+    activePenalties[team].push(interval);
 }
 
 


### PR DESCRIPTION
## Summary
- allow scoreboard to display yellow/red cards and 2‑minute penalties
- show countdown timers for penalties

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68540704a590832dad53fec90b4610e2