### PR TITLE
Style next match popup

### DIFF
--- a/scoreboard.css
+++ b/scoreboard.css
@@ -480,3 +480,50 @@
         font-size: 4vw;
     }
 }
+
+/* Next Match Popup */
+#nextMatchModal .modal-content {
+    text-align: center;
+    padding: 2rem;
+    max-width: 400px;
+}
+
+#nextMatchModal h2 {
+    margin-top: 0;
+    color: #1a202c;
+}
+
+#nextMatchModal p {
+    margin: 1rem 0;
+    font-size: 1.2rem;
+}
+
+#nextMatchModal .time-button {
+    font-size: 1.25rem;
+    padding: 0.75rem 1rem;
+    border: none;
+    border-radius: 10px;
+    background-color: #007bff;
+    color: white;
+    cursor: pointer;
+    min-width: 200px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    white-space: normal;
+    transition: background-color 0.3s ease, transform 0.2s;
+}
+
+#nextMatchModal .time-button:hover {
+    background-color: #0056b3;
+    transform: scale(1.05);
+}
+
+#nextMatchModal .time-button:active {
+    transform: scale(0.95);
+}
+
+#nextMatchModal .next-match-actions {
+    margin-top: 1rem;
+}

--- a/scoreboard.html
+++ b/scoreboard.html
@@ -151,7 +151,7 @@
     <span class="close" onclick="closeNextMatchModal()">&times;</span>
     <h2>Neste kamp på banen</h2>
     <p id="nextMatchInfo">Ingen flere kamper.</p>
-    <div style="text-align:center;margin-top:1rem;">
+    <div class="next-match-actions">
       <button id="goToNextMatchBtn" class="time-button">Gå til neste kamp</button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- restyle the popup for the next match in `scoreboard.html`
- apply new CSS rules to `scoreboard.css`
- enlarge the button for going to the next match

## Testing
- `npm test` *(fails: cannot find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6854090ab36c832d9032b941e5e676ba