### PR TITLE
Reduce scoreboard vertical layout

### DIFF
--- a/basicscore.html
+++ b/basicscore.html
@@ -97,7 +97,8 @@
     #breakTimer { font-size: min(3vw, 4vh); margin-bottom: 1rem; color: #ff5722; text-align: center; display: none; }
 
     /* Score-seksjon */
-    .scores { display: flex; justify-content: space-between; width: 100%; }
+    .scores { display: flex; justify-content: center; align-items: center; gap: 2rem; width: 100%; }
+    .scores #timer { margin: 0 1rem; }
     .score-section { flex: 1; display: flex; flex-direction: column; align-items: center; margin: 0 .5rem; }
     .score { font-size: min(9vw, 10vh); color: #007bff; margin-bottom: .5rem; }
     .team-name { font-size: min(3vw, 4vh); margin-bottom: 1rem; text-transform: uppercase; }
@@ -128,7 +129,6 @@
         </div>
         <div class="scoreboard-container">
             <div class="scoreboard" id="scoreboard">
-                <div id="timer">00:00</div>
                 <div id="period">1. omgang</div>
                 <div id="breakTimer"></div>
                 <div class="scores">
@@ -140,6 +140,7 @@
                             <button class="score-button" id="decHome">-</button>
                         </div>
                     </div>
+                    <div id="timer">00:00</div>
                     <div class="score-section">
                         <div id="scoreAway" class="score">0</div>
                         <div class="team-name">Borte</div>

--- a/scoreboard.css
+++ b/scoreboard.css
@@ -222,8 +222,14 @@
       /* Scores */
       .scores {
           display: flex;
-          justify-content: space-between;
+          justify-content: center;
+          align-items: center;
+          gap: 2rem;
           width: 100%;
+      }
+
+      .scores .timer {
+          margin: 0 1rem;
       }
     
       .score-section {

--- a/scoreboard.html
+++ b/scoreboard.html
@@ -26,7 +26,6 @@
                     <button class="time-button" onclick="adjustTime(1)">+1s</button>
                     <button class="time-button" onclick="adjustTime(-1)">-1s</button>
                 </div>
-                <div class="timer" id="timer">15:00</div>
                 <!-- Resten av innholdet forblir uendret -->
                 <div class="timeout-timer" id="timeoutTimer" style="display:none;">Timeout: 30s</div>
                 <div class="period" id="period">1. omgang</div>
@@ -47,6 +46,7 @@
                         <div id="hjemmeCards" class="card-display"></div>
                         <div id="hjemmePenalties" class="penalty-display"></div>
                     </div>
+                    <div class="timer" id="timer">15:00</div>
                     <div class="score-section" id="borteSection">
                         <div id="borteScore" class="score">0</div>
                         <div class="team-name" id="bortelagNavn">Lag 2</div>
@@ -1463,9 +1463,11 @@ async function updateTeamStatsAfterReset(hjemmelag, bortelag, hjemmeScore, borte
             const scoresContainer = document.getElementById('scoresContainer');
             const hjemmeSection = document.getElementById('hjemmeSection');
             const borteSection = document.getElementById('borteSection');
+            const timerEl = document.getElementById('timer');
 
-            // Bytt rekkefølge på elementene
-            scoresContainer.insertBefore(borteSection, hjemmeSection);
+            // Plasser borteseksjonen til venstre og hjemmelaget til høyre
+            scoresContainer.insertBefore(borteSection, timerEl);
+            scoresContainer.appendChild(hjemmeSection);
 
             // Oppdater Firebase med byttet
             db.collection('turneringer').doc(turneringId).collection('kamper').doc(kampId).update({


### PR DESCRIPTION
## Summary
- reposition timer between score sections in both scoreboard pages
- center the timer on side switches
- adjust layout styles for compact scoreboard

## Testing
- `git diff --check`


------
https://chatgpt.com/codex/tasks/task_e_68569cfa1ea0832d909d487ddc75d016