### PR TITLE
Add robots sitemap

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://<ditt-domene>/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://<ditt-domene>/OpprettTurnering.html</loc></url>
+  <url><loc>https://<ditt-domene>/basicscore.html</loc></url>
+  <url><loc>https://<ditt-domene>/dommerdetaljer.html</loc></url>
+  <url><loc>https://<ditt-domene>/dommere.html</loc></url>
+  <url><loc>https://<ditt-domene>/faq.html</loc></url>
+  <url><loc>https://<ditt-domene>/feedback.html</loc></url>
+  <url><loc>https://<ditt-domene>/format.html</loc></url>
+  <url><loc>https://<ditt-domene>/index.html</loc></url>
+  <url><loc>https://<ditt-domene>/instillinger.html</loc></url>
+  <url><loc>https://<ditt-domene>/kampdetaljer.html</loc></url>
+  <url><loc>https://<ditt-domene>/kamper.html</loc></url>
+  <url><loc>https://<ditt-domene>/kampliste.html</loc></url>
+  <url><loc>https://<ditt-domene>/kampoppsett.html</loc></url>
+  <url><loc>https://<ditt-domene>/lagdetaljer.html</loc></url>
+  <url><loc>https://<ditt-domene>/lagoversikt.html</loc></url>
+  <url><loc>https://<ditt-domene>/leggtillag.html</loc></url>
+  <url><loc>https://<ditt-domene>/login.html</loc></url>
+  <url><loc>https://<ditt-domene>/manualMatches.html</loc></url>
+  <url><loc>https://<ditt-domene>/manualTurnering.html</loc></url>
+  <url><loc>https://<ditt-domene>/nyTurnering.html</loc></url>
+  <url><loc>https://<ditt-domene>/publikum.html</loc></url>
+  <url><loc>https://<ditt-domene>/qanda.html</loc></url>
+  <url><loc>https://<ditt-domene>/registrer.html</loc></url>
+  <url><loc>https://<ditt-domene>/scoreboard.html</loc></url>
+  <url><loc>https://<ditt-domene>/settings.html</loc></url>
+  <url><loc>https://<ditt-domene>/slideshowEditor.html</loc></url>
+  <url><loc>https://<ditt-domene>/tabell.html</loc></url>
+  <url><loc>https://<ditt-domene>/toppscorer.html</loc></url>
+  <url><loc>https://<ditt-domene>/turnering.html</loc></url>
+</urlset>


### PR DESCRIPTION
## Summary
- add robots.txt
- add sitemap with canonical URLs for all pages

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68569d836f88832dbdc563282c712cb2