### PR TITLE
Add alt text to images

### DIFF
--- a/OpprettTurnering.html
+++ b/OpprettTurnering.html
@@ -123,7 +123,7 @@
 <body>
     <header>
         <div class="logo-title">
-          <a href="nyTurnering.html"><img src="logo.png" alt="Simple Scores Logo" class="logo"></a>
+          <a href="nyTurnering.html"><img src="logo.png" alt="Simple Scores logo" class="logo"></a>
         </div>
         <div class="nav2">
           <button id="user-button" onclick="toggleUserMenu()" class="bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded">Bruker</button>

--- a/dommerdetaljer.html
+++ b/dommerdetaljer.html
@@ -13,7 +13,7 @@
 <body>
     <header>
         <div class="logo-title">
-            <img src="logo.png" alt="Simple Scores-logo" class="logo">
+            <img src="logo.png" alt="Simple Scores logo" class="logo">
         </div>
     </header>
 

--- a/dommere.html
+++ b/dommere.html
@@ -45,7 +45,7 @@
 <body>
     <header>
         <div class="logo-title">
-            <img src="logo.png" alt="Simple Scores-logo" class="logo">
+            <img src="logo.png" alt="Simple Scores logo" class="logo">
         </div>
     </header>
 

--- a/faq.html
+++ b/faq.html
@@ -60,7 +60,7 @@
 </head>
 <body class="font-[Poppins,sans-serif] bg-gray-100 text-gray-800">
   <header class="bg-gray-900 py-8 text-center">
-    <img src="logo.png" alt="Simple Scores Logo" class="mx-auto h-48">
+    <img src="logo.png" alt="Simple Scores logo" class="mx-auto h-48">
   </header>
   <main class="max-w-3xl mx-auto my-8 p-6 bg-white rounded-lg shadow">
     <h1 class="text-2xl font-bold mb-6">FAQ – Frequently Asked Questions</h1>

--- a/feedback.html
+++ b/feedback.html
@@ -47,7 +47,7 @@
 <body class="font-[Poppins,sans-serif] bg-gray-100 text-gray-800">
   <header class="bg-gray-900 py-8 text-center">
     <a href="index.html">
-      <img src="logo.png" alt="Simple Scores Logo" class="mx-auto h-48">
+      <img src="logo.png" alt="Simple Scores logo" class="mx-auto h-48">
     </a>
   </header>
   <main class="max-w-md mx-auto my-8 p-6 bg-white rounded-lg shadow">

--- a/format.html
+++ b/format.html
@@ -58,7 +58,7 @@
 <body>
     <header>
         <div class="logo-title">
-            <a href="nyTurnering.html"><img src="logo.png" alt="Simple Scores Logo" class="logo"></a>
+            <a href="nyTurnering.html"><img src="logo.png" alt="Simple Scores logo" class="logo"></a>
         </div>
         <div class="nav2">
             <button id="user-button" onclick="toggleUserMenu()">User</button>

--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
   <body class="font-[Poppins,sans-serif] bg-gray-100 text-gray-800">
   <main>
     <section class="bg-gradient-to-br from-[#3b3f73] to-[#2f8656] text-white text-center py-20">
-      <img src="logo.png" alt="Simple Scores" class="mx-auto h-36 mb-6">
+      <img src="logo.png" alt="Simple Scores logo" class="mx-auto h-36 mb-6">
       <h1 class="text-5xl font-bold text-green-300 mb-2">Simple Scores</h1>
       <p class="text-lg mb-8">Din raske vei til oppdaterte resultater og turneringer.</p>
       <div class="flex flex-wrap justify-center gap-4">

--- a/instillinger.html
+++ b/instillinger.html
@@ -85,7 +85,7 @@
   <header>
     <div class="logo-title">
       <a href="nyTurnering.html">
-        <img src="logo.png" alt="Simple Scores Logo" class="logo">
+        <img src="logo.png" alt="Simple Scores logo" class="logo">
       </a>
     </div>
     <button id="user-button" class="user-button" onclick="toggleUserMenu()">Bruker</button>

--- a/kampdetaljer.html
+++ b/kampdetaljer.html
@@ -184,7 +184,7 @@
 <body>
     <header>
         <div class="logo-title">
-            <img src="logo.png" alt="Simple Scores Logo" class="logo">
+            <img src="logo.png" alt="Simple Scores logo" class="logo">
         </div>
     </header>
 

--- a/kamper.html
+++ b/kamper.html
@@ -167,7 +167,7 @@
 <body>
   <header>
     <div class="logo-title">
-      <a href="nyTurnering.html"><img src="logo.png" alt="Simple Scores Logo" class="logo"></a>
+      <a href="nyTurnering.html"><img src="logo.png" alt="Simple Scores logo" class="logo"></a>
     </div>
     <div class="nav2">
       <button id="user-button" onclick="toggleUserMenu()">Bruker</button>

--- a/kampliste.html
+++ b/kampliste.html
@@ -168,7 +168,7 @@
 </head>
 <body>
   <header>
-    <img src="logo.png" alt="Simple Scores-logo" class="logo">
+    <img src="logo.png" alt="Simple Scores logo" class="logo">
     <button id="hamburgerBtn" class="hamburger" aria-label="Åpne meny">
       <span></span><span></span><span></span>
     </button>

--- a/kampoppsett.html
+++ b/kampoppsett.html
@@ -292,7 +292,7 @@
     <body id="wrapper">
         <header>
             <div class="logo-title">
-                <a href="nyTurnering.html"><img src="logo.png" alt="Simple Scores Logo" class="logo"></a>
+                <a href="nyTurnering.html"><img src="logo.png" alt="Simple Scores logo" class="logo"></a>
             </div>
             <div class="nav2">
                 <button id="user-button" onclick="toggleUserMenu()">Bruker</button>

--- a/lagdetaljer.html
+++ b/lagdetaljer.html
@@ -80,7 +80,7 @@
 <body>
   <header>
     <div class="logo-title">
-      <img src="logo.png" alt="Simple Scores Logo" class="logo">
+      <img src="logo.png" alt="Simple Scores logo" class="logo">
     </div>
   </header>
 

--- a/lagoversikt.html
+++ b/lagoversikt.html
@@ -45,7 +45,7 @@
 <body>
     <header>
         <div class="logo-title">
-            <img src="logo.png" alt="Simple Scores Logo" class="logo">
+            <img src="logo.png" alt="Simple Scores logo" class="logo">
         </div>
     </header>
 

--- a/leggtillag.html
+++ b/leggtillag.html
@@ -226,7 +226,7 @@
 
   <header>
     <div class="logo-title">
-      <a href="nyTurnering.html"><img src="logo.png" alt="Simple Scores Logo" class="logo"></a>
+      <a href="nyTurnering.html"><img src="logo.png" alt="Simple Scores logo" class="logo"></a>
     </div>
     <div class="nav2">
       <button id="user-button" onclick="toggleUserMenu()">User</button>

--- a/login.html
+++ b/login.html
@@ -177,7 +177,7 @@
 <body>
     <div class="container">
         <div class="logo-section">
-            <img src="logo.png" alt="Simple Scores Logo">
+            <img src="logo.png" alt="Simple Scores logo">
         </div>
         <div class="login-section">
             <h2>Sign in</h2>

--- a/manualMatches.html
+++ b/manualMatches.html
@@ -63,7 +63,7 @@
 <body>
   <header>
     <div class="logo-title">
-      <a href="nyTurnering.html"><img src="logo.png" alt="Simple Scores Logo" class="logo"></a>
+      <a href="nyTurnering.html"><img src="logo.png" alt="Simple Scores logo" class="logo"></a>
     </div>
     <div class="nav2">
       <button id="user-button" onclick="toggleUserMenu()">Bruker</button>

--- a/manualTurnering.html
+++ b/manualTurnering.html
@@ -10,7 +10,7 @@
 <body>
   <header>
     <div class="logo-title">
-      <a href="index.html"><img src="logo.png" alt="Simple Scores Logo" class="logo"></a>
+      <a href="index.html"><img src="logo.png" alt="Simple Scores logo" class="logo"></a>
     </div>
     <div class="nav2">
       <button id="user-button" onclick="toggleUserMenu()">Bruker</button>

--- a/nyTurnering.html
+++ b/nyTurnering.html
@@ -21,7 +21,7 @@
 <body id="wrapper">
   <header>
     <div class="logo-title">
-      <a href="index.html"><img src="logo.png" alt="Simple Scores Logo" class="logo"></a>
+      <a href="index.html"><img src="logo.png" alt="Simple Scores logo" class="logo"></a>
     </div>
     <div class="nav2">
       <button id="user-button" onclick="toggleUserMenu()">Bruker</button>

--- a/publikum.html
+++ b/publikum.html
@@ -16,7 +16,7 @@
 <body>
     <header>
         <div class="logo-title">
-            <img src="logo.png" alt="Simple Scores Logo" class="logo">
+            <img src="logo.png" alt="Simple Scores logo" class="logo">
         </div>
         <button onclick="window.location.href='login.html'">Admin</button>
     </header>

--- a/qanda.html
+++ b/qanda.html
@@ -46,7 +46,7 @@
 </head>
 <body>
   <header>
-    <a href="index.html"><img src="logo.png" alt="Simple Scores Logo" style="height:80px"></a>
+    <a href="index.html"><img src="logo.png" alt="Simple Scores logo" style="height:80px"></a>
     <h1>Q&amp;A – Spørsmål og svar</h1>
   </header>
   <main>

--- a/registrer.html
+++ b/registrer.html
@@ -194,7 +194,7 @@
     <div class="container">
         <!-- Logo Section -->
         <div class="logo-section">
-            <img src="logo.png" alt="Simple Scores Logo">
+            <img src="logo.png" alt="Simple Scores logo">
         </div>
 
         <!-- Register Section -->

--- a/settings.html
+++ b/settings.html
@@ -71,7 +71,7 @@
 <body>
     <header>
         <div class="logo-title">
-            <a href="nyTurnering.html"><img src="logo.png" alt="Simple Scores Logo" class="logo"></a>
+            <a href="nyTurnering.html"><img src="logo.png" alt="Simple Scores logo" class="logo"></a>
         </div>
         <div class="nav2">
             <button id="user-button" onclick="toggleUserMenu()">Bruker</button>

--- a/slideshowEditor.html
+++ b/slideshowEditor.html
@@ -398,7 +398,7 @@
 <body>
   <header>
     <div class="logo-title">
-        <a href="nyTurnering.html"><img src="logo.png" alt="Simple Scores Logo" class="logo"></a>
+        <a href="nyTurnering.html"><img src="logo.png" alt="Simple Scores logo" class="logo"></a>
     </div>
     <div class="nav2">
         <button id="user-button" onclick="toggleUserMenu()">Bruker</button>

--- a/tabell.html
+++ b/tabell.html
@@ -310,7 +310,7 @@
 <body>
   <header>
     <div class="logo-title">
-      <img src="logo.png" alt="Simple Scores Logo" class="logo" />
+      <img src="logo.png" alt="Simple Scores logo" class="logo" />
     </div>
   </header>
 

--- a/toppscorer.html
+++ b/toppscorer.html
@@ -13,7 +13,7 @@
 <body>
     <header>
         <div class="logo-title">
-            <img src="logo.png" alt="Simple Scores Logo" class="logo">
+            <img src="logo.png" alt="Simple Scores logo" class="logo">
         </div>
     </header>
 

--- a/turnering.html
+++ b/turnering.html
@@ -111,7 +111,7 @@
 <body>
     <header>
         <div class="logo-title">
-            <img src="logo.png" alt="Simple Scores Logo" class="logo">
+            <img src="logo.png" alt="Simple Scores logo" class="logo">
         </div>
     </header>
 


### PR DESCRIPTION
## Summary
- ensure `<img>` tags all describe the logo succinctly via `alt="Simple Scores logo"`

## Testing
- `grep -n "alt=\"" *.html`

------
https://chatgpt.com/codex/tasks/task_e_68569d857360832db65c3a7386f00265