### PR TITLE
Add Open Graph meta tags to HTML pages

### DIFF
--- a/OpprettTurnering.html
+++ b/OpprettTurnering.html
@@ -6,6 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">    
     <link rel="stylesheet" type="text/css" href="./admin.css">
     <title>Opprett Turnering</title>
+  <meta property="og:title" content="Opprett Turnering">
+  <meta property="og:description" content="Opprett en ny turnering i systemet.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/OpprettTurnering.html">
     <style>
         /* Reset CSS */
         * {

--- a/basicscore.html
+++ b/basicscore.html
@@ -5,6 +5,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Basic Scoreboard</title>
+  <meta property="og:title" content="Basic Scoreboard">
+  <meta property="og:description" content="Enkel tavle for kampscorer.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/basicscore.html">
     <style>
     /* Generell Styling */
     body {

--- a/dommerdetaljer.html
+++ b/dommerdetaljer.html
@@ -5,6 +5,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dommerdetaljer - Turnering</title>
+  <meta property="og:title" content="Dommerdetaljer - Turnering">
+  <meta property="og:description" content="Detaljer om dommerne i turneringen.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/dommerdetaljer.html">
     <link rel="stylesheet" type="text/css" href="./style.css">
     <script src="https://www.gstatic.com/firebasejs/8.2.0/firebase-app.js"></script>
     <script src="firebaseConfig.js"></script>

--- a/dommere.html
+++ b/dommere.html
@@ -5,6 +5,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Dommere - Turnering</title>
+  <meta property="og:title" content="Dommere - Turnering">
+  <meta property="og:description" content="Oversikt over dommerne i turneringen.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/dommere.html">
     <link rel="stylesheet" type="text/css" href="./style.css">
     <style>
         .team-list {

--- a/faq.html
+++ b/faq.html
@@ -4,6 +4,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>FAQ – Simple Scores</title>
+  <meta property="og:title" content="FAQ – Simple Scores">
+  <meta property="og:description" content="Ofte stilte spårsmål om Simple Scores.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/faq.html">
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <script type="application/ld+json">

--- a/feedback.html
+++ b/feedback.html
@@ -4,6 +4,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Gi tilbakemelding</title>
+  <meta property="og:title" content="Gi tilbakemelding">
+  <meta property="og:description" content="Send oss din tilbakemelding.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/feedback.html">
   <script src="https://cdn.tailwindcss.com"></script>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <style>

--- a/format.html
+++ b/format.html
@@ -3,6 +3,10 @@
 <head>
   <script src="https://cdn.tailwindcss.com"></script>
     <title>Velg format</title>
+  <meta property="og:title" content="Velg format">
+  <meta property="og:description" content="Velg kampformat.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/format.html">
     <meta charset="utf-8">
     <link rel="stylesheet" type="text/css" href="./admin.css">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -4,16 +4,15 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <meta charset="UTF-8">
   <title>Simple Scores – Score Service</title>
+  <meta property="og:title" content="Simple Scores – Score Service">
+  <meta property="og:description" content="Startside for Simple Scores.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/index.html">
   <meta name="description" content="Oppdag Simple Scores, din tjeneste for live resultater og oppdateringer.">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="canonical" href="https://dinsideeksempel.no/">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <!-- Open Graph meta tags -->
-  <meta property="og:title" content="Simple Scores – Score Service">
-  <meta property="og:description" content="Din tjeneste for live resultater og oppdateringer.">
-  <meta property="og:image" content="logo.png">
-  <meta property="og:url" content="https://dinsideeksempel.no/">
-  <meta property="og:type" content="website">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/instillinger.html
+++ b/instillinger.html
@@ -7,6 +7,10 @@
   <!-- Bruk den generelle CSS-filen -->
   <link rel="stylesheet" type="text/css" href="./admin.css">
   <title>Generelle Innstillinger</title>
+  <meta property="og:title" content="Generelle Innstillinger">
+  <meta property="og:description" content="Juster generelle innstillinger for appen.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/instillinger.html">
   <style>
     /* Egendefinert styling for denne siden */
     .settings-container {

--- a/kampdetaljer.html
+++ b/kampdetaljer.html
@@ -4,6 +4,10 @@
   <script src="https://cdn.tailwindcss.com"></script>
     <meta charset="UTF-8">
     <title>Kampdetaljer - Turnering</title>
+  <meta property="og:title" content="Kampdetaljer - Turnering">
+  <meta property="og:description" content="Detaljer for en enkelt kamp.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/kampdetaljer.html">
     <!-- Google Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
     <!-- Firebase SDKs -->

--- a/kamper.html
+++ b/kamper.html
@@ -5,6 +5,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Kampoversikt Resultatservice</title>
+  <meta property="og:title" content="Kampoversikt Resultatservice">
+  <meta property="og:description" content="Se oversikten over alle kamper.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/kamper.html">
   <link rel="stylesheet" href="admin.css">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <style>

--- a/kampliste.html
+++ b/kampliste.html
@@ -5,6 +5,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Kamper - Turnering</title>
+  <meta property="og:title" content="Kamper - Turnering">
+  <meta property="og:description" content="Lister alle kamper i turneringen.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/kampliste.html">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
   <style>

--- a/kampoppsett.html
+++ b/kampoppsett.html
@@ -3,6 +3,10 @@
     <head>
   <script src="https://cdn.tailwindcss.com"></script>
         <title>Kampoppsett</title>
+  <meta property="og:title" content="Kampoppsett">
+  <meta property="og:description" content="Planlegg kampoppsettet.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/kampoppsett.html">
         <meta charset="utf-8">
         <link rel="stylesheet" type="text/css" href="./admin.css">
         <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">

--- a/lagdetaljer.html
+++ b/lagdetaljer.html
@@ -5,6 +5,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Lagdetaljer - Turnering</title>
+  <meta property="og:title" content="Lagdetaljer - Turnering">
+  <meta property="og:description" content="Informasjon om lagene i turneringen.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/lagdetaljer.html">
   <link rel="stylesheet" href="./style.css">
   <!-- Kun styling for kamp-listen fra kampliste.html -->
   <style>

--- a/lagoversikt.html
+++ b/lagoversikt.html
@@ -5,6 +5,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Lagoversikt - Turnering</title>
+  <meta property="og:title" content="Lagoversikt - Turnering">
+  <meta property="og:description" content="Oversikt over alle lagene.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/lagoversikt.html">
     <link rel="stylesheet" type="text/css" href="./style.css">
     <style>
         .team-list {

--- a/leggtillag.html
+++ b/leggtillag.html
@@ -5,6 +5,10 @@
   <meta charset="utf8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Legg til lag</title>
+  <meta property="og:title" content="Legg til lag">
+  <meta property="og:description" content="Registrer et nytt lag.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/leggtillag.html">
   <link rel="stylesheet" type="text/css" href="./admin.css">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
   <style>

--- a/login.html
+++ b/login.html
@@ -6,6 +6,10 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
   <meta charset="utf-8">
   <title>Login</title>
+  <meta property="og:title" content="Login">
+  <meta property="og:description" content="Logg inn for å administrere scorer.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/login.html">
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <style>

--- a/manualMatches.html
+++ b/manualMatches.html
@@ -5,6 +5,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Manuell kampoversikt</title>
+  <meta property="og:title" content="Manuell kampoversikt">
+  <meta property="og:description" content="Legg til og rediger kamper manuelt.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/manualMatches.html">
   <link rel="stylesheet" href="admin.css">
   <style>
     .kamp-item {

--- a/manualTurnering.html
+++ b/manualTurnering.html
@@ -6,6 +6,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="admin.css">
   <title>Manuell Turnering</title>
+  <meta property="og:title" content="Manuell Turnering">
+  <meta property="og:description" content="Opprett og administrer en manuell turnering.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/manualTurnering.html">
 </head>
 <body>
   <header>

--- a/nyTurnering.html
+++ b/nyTurnering.html
@@ -6,6 +6,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="./admin.css">
   <title>Legg til Turnering</title>
+  <meta property="og:title" content="Legg til Turnering">
+  <meta property="og:description" content="Registrer en ny turnering.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/nyTurnering.html">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <!-- Ekstra stil for turneringskortene -->
     <style>

--- a/publikum.html
+++ b/publikum.html
@@ -5,6 +5,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Turneringsoversikt</title>
+  <meta property="og:title" content="Turneringsoversikt">
+  <meta property="og:description" content="Publikumsvisning av turneringen.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/publikum.html">
     <link rel="stylesheet" type="text/css" href="./style.css">
     <!-- Google Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">

--- a/qanda.html
+++ b/qanda.html
@@ -4,6 +4,10 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Q&A – Spørsmål og svar</title>
+  <meta property="og:title" content="Q&A – Spørsmål og svar">
+  <meta property="og:description" content="Spørsmål og svar om tjenesten.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/qanda.html">
   <link rel="stylesheet" href="admin.css">
   <style>
     body {

--- a/registrer.html
+++ b/registrer.html
@@ -4,6 +4,10 @@
   <script src="https://cdn.tailwindcss.com"></script>
     <meta charset="UTF-8">
     <title>Register</title>
+  <meta property="og:title" content="Register">
+  <meta property="og:description" content="Registrer deg som bruker.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/registrer.html">
     <link rel="stylesheet" type="text/css" href="./admin.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <style>

--- a/scoreboard.html
+++ b/scoreboard.html
@@ -5,6 +5,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Scoreboard</title>
+  <meta property="og:title" content="Scoreboard">
+  <meta property="og:description" content="Live oppdatering av scorene.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/scoreboard.html">
     <link rel="stylesheet" href="scoreboard.css">
 </head>
 <body>

--- a/settings.html
+++ b/settings.html
@@ -5,6 +5,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Innstillinger for Scoreboard</title>
+  <meta property="og:title" content="Innstillinger for Scoreboard">
+  <meta property="og:description" content="Tilpass innstillinger for scoreboardet.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/settings.html">
     <link rel="stylesheet" href="admin.css">
     <style>
         body {

--- a/slideshowEditor.html
+++ b/slideshowEditor.html
@@ -5,6 +5,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Slide Editor</title>
+  <meta property="og:title" content="Slide Editor">
+  <meta property="og:description" content="Rediger presentasjoner for scorevisning.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/slideshowEditor.html">
   <link rel="stylesheet" type="text/css" href="./admin.css">
   <style>
 /* Wrapper rundt hele braketten */

--- a/tabell.html
+++ b/tabell.html
@@ -4,6 +4,10 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <meta charset="UTF-8" />
   <title>Alle divisjons- og fase-tabeller</title>
+  <meta property="og:title" content="Alle divisjons- og fase-tabeller">
+  <meta property="og:description" content="Se tabeller for alle divisjoner og faser.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/tabell.html">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 
   <!-- Google Fonts -->

--- a/toppscorer.html
+++ b/toppscorer.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Toppscorere</title>
+  <meta property="og:title" content="Toppscorere">
+  <meta property="og:description" content="Oversikt over toppscorerne.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/toppscorer.html">
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="style.css">
     <script src="https://www.gstatic.com/firebasejs/8.2.0/firebase-app.js"></script>

--- a/turnering.html
+++ b/turnering.html
@@ -5,6 +5,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Turneringsdetaljer - Turnering</title>
+  <meta property="og:title" content="Turneringsdetaljer - Turnering">
+  <meta property="og:description" content="Detaljer for turneringen.">
+  <meta property="og:image" content="logo.png">
+  <meta property="og:url" content="https://ditt-domene.no/turnering.html">
     <link rel="stylesheet" type="text/css" href="./style.css">
     <!-- Google Fonts -->
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- add og:title, og:description, og:image and og:url tags to all HTML pages
- customize title and description for each page

## Testing
- `python3 --version`


------
https://chatgpt.com/codex/tasks/task_e_68569d8122e0832d8376f5954e63b978