### PR TITLE
Reduce scoreboard vertical layout

### DIFF
--- a/basicscore.html
+++ b/basicscore.html
@@ -92,12 +92,13 @@
     }
 
     /* Timer og omgangen */
-    #timer { font-size: min(6vw, 10vh); margin-bottom: .5rem; letter-spacing: 4px; }
+    #timer { font-size: min(10vw, 12vh); margin-bottom: .5rem; letter-spacing: 4px; }
     #period { font-size: min(3vw, 4vh); margin-bottom: 1rem; text-transform: uppercase; }
     #breakTimer { font-size: min(3vw, 4vh); margin-bottom: 1rem; color: #ff5722; text-align: center; display: none; }
 
     /* Score-seksjon */
-    .scores { display: flex; justify-content: space-between; width: 100%; }
+    .scores { display: flex; justify-content: center; align-items: center; gap: 2rem; width: 100%; }
+    .scores #timer { margin: 0 1rem; }
     .score-section { flex: 1; display: flex; flex-direction: column; align-items: center; margin: 0 .5rem; }
     .score { font-size: min(9vw, 10vh); color: #007bff; margin-bottom: .5rem; }
     .team-name { font-size: min(3vw, 4vh); margin-bottom: 1rem; text-transform: uppercase; }
@@ -113,7 +114,8 @@
     .modal-content { background: #fff; padding: 1.5rem; border-radius: 10px; text-align: center; }
 
     @media(max-width:768px) {
-        #timer, .score { font-size: min(12vw, 15vh); }
+        #timer { font-size: min(14vw, 18vh); }
+        .score { font-size: min(12vw, 15vh); }
         #period, .team-name { font-size: min(5vw, 6vh); }
         .score-button, .controls button, .side-panel button { width: 120px; height: 50px; font-size: 1.5rem; padding: .5rem .75rem; }
         .scoreboard { max-width: 90%; }
@@ -128,7 +130,6 @@
         </div>
         <div class="scoreboard-container">
             <div class="scoreboard" id="scoreboard">
-                <div id="timer">00:00</div>
                 <div id="period">1. omgang</div>
                 <div id="breakTimer"></div>
                 <div class="scores">
@@ -140,6 +141,7 @@
                             <button class="score-button" id="decHome">-</button>
                         </div>
                     </div>
+                    <div id="timer">00:00</div>
                     <div class="score-section">
                         <div id="scoreAway" class="score">0</div>
                         <div class="team-name">Borte</div>

--- a/scoreboard.css
+++ b/scoreboard.css
@@ -187,7 +187,7 @@
     
       /* Øk font-størrelsen på tidtakeren */
       .timer {
-          font-size: min(16vw, 14vh);    /* Større tall uten å fylle mer enn en skjerm */
+          font-size: min(18vw, 16vh);    /* Enda større tall uten å fylle mer enn skjermen */
           margin-bottom: 0.5rem;
           letter-spacing: 4px;
           color: #2d3e50;
@@ -222,8 +222,14 @@
       /* Scores */
       .scores {
           display: flex;
-          justify-content: space-between;
+          justify-content: center;
+          align-items: center;
+          gap: 2rem;
           width: 100%;
+      }
+
+      .scores .timer {
+          margin: 0 1rem;
       }
     
       .score-section {
@@ -377,7 +383,7 @@
       /* Responsiv justering av fontstørrelser for mindre skjermer */
       @media (max-width: 768px) {
           .timer, .score {
-              font-size: 25vw;
+              font-size: 28vw;
           }
           .period, .team-name, .timeout-timer {
               font-size: 5vw;
@@ -455,7 +461,7 @@
     
 @media (max-width: 480px) {
     .timer, .score {
-        font-size: 28vw;
+        font-size: 32vw;
     }
     .period, .team-name, .timeout-timer {
         font-size: 6vw;
@@ -474,7 +480,7 @@
 
 @media (min-width: 769px) and (max-width: 1024px) {
     .timer, .score {
-        font-size: 18vw;
+        font-size: 20vw;
     }
     .period, .team-name, .timeout-timer {
         font-size: 4vw;

--- a/scoreboard.html
+++ b/scoreboard.html
@@ -26,7 +26,6 @@
                     <button class="time-button" onclick="adjustTime(1)">+1s</button>
                     <button class="time-button" onclick="adjustTime(-1)">-1s</button>
                 </div>
-                <div class="timer" id="timer">15:00</div>
                 <!-- Resten av innholdet forblir uendret -->
                 <div class="timeout-timer" id="timeoutTimer" style="display:none;">Timeout: 30s</div>
                 <div class="period" id="period">1. omgang</div>
@@ -47,6 +46,7 @@
                         <div id="hjemmeCards" class="card-display"></div>
                         <div id="hjemmePenalties" class="penalty-display"></div>
                     </div>
+                    <div class="timer" id="timer">15:00</div>
                     <div class="score-section" id="borteSection">
                         <div id="borteScore" class="score">0</div>
                         <div class="team-name" id="bortelagNavn">Lag 2</div>
@@ -1463,9 +1463,11 @@ async function updateTeamStatsAfterReset(hjemmelag, bortelag, hjemmeScore, borte
             const scoresContainer = document.getElementById('scoresContainer');
             const hjemmeSection = document.getElementById('hjemmeSection');
             const borteSection = document.getElementById('borteSection');
+            const timerEl = document.getElementById('timer');
 
-            // Bytt rekkefølge på elementene
-            scoresContainer.insertBefore(borteSection, hjemmeSection);
+            // Plasser borteseksjonen til venstre og hjemmelaget til høyre
+            scoresContainer.insertBefore(borteSection, timerEl);
+            scoresContainer.appendChild(hjemmeSection);
 
             // Oppdater Firebase med byttet
             db.collection('turneringer').doc(turneringId).collection('kamper').doc(kampId).update({


### PR DESCRIPTION
## Summary
- reposition timer between score sections in both scoreboard pages
- center the timer on side switches
- adjust layout styles for compact scoreboard
- increase timer font size for better visibility

## Testing
- `git diff --check`


------
https://chatgpt.com/codex/tasks/task_e_68569cfa1ea0832d909d487ddc75d016